### PR TITLE
fix: minishellに対するリダイレクトの挙動をbashと一致させた

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/02/19 17:45:02 by tkondo           ###   ########.fr        #
+#    Updated: 2025/02/20 14:34:25 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -48,7 +48,7 @@ TARGET =\
 	read/get_input\
 	redirect/resolve_redirects\
 	signal/at_sigint\
-	utils/close_fd_safely\
+	utils/close_fds_no_stdio\
 	signal/set_handlers_for_prompt\
 	signal/set_handlers_default\
 	signal/set_handlers_for_process\

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/19 17:20:33 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:33:53 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ struct							s_redirect
 extern volatile unsigned char	g_signal;
 
 bool							init(void);
-void							close_fds_safely(int *fds, size_t size);
+void							close_fds_no_stdio(int *fds, size_t size);
 t_simple_cmd					*pipe2simple_cmds(const char *pipe);
 bool							iterate_pipefd(bool is_first, bool is_last,
 									int (*stdio)[2], int *next_in);

--- a/src/main/eval_pipe.c
+++ b/src/main/eval_pipe.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:33:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/17 04:48:22 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:32:50 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,13 +40,13 @@ unsigned char	eval_pipe(const char *text, char **envp)
 		{
 			// TODO: consider about pipe failure case
 			free_simple_cmds((t_simple_cmd *)cmds);
-			close_fds_safely(stdio_fd, 2);
-			close_fds_safely(&next_in_fd, 1);
+			close_fds_no_stdio(stdio_fd, 2);
+			close_fds_no_stdio(&next_in_fd, 1);
 		}
 		execute_simple_cmd(cmds[i], stdio_fd, next_in_fd, envp);
 		i++;
 	}
 	free_simple_cmds((t_simple_cmd *)cmds);
-	close_fds_safely((int [3]){stdio_fd[0], stdio_fd[1], next_in_fd}, 3);
+	close_fds_no_stdio((int [3]){stdio_fd[0], stdio_fd[1], next_in_fd}, 3);
 	return (wait_status());
 }

--- a/src/main/execute_simple_cmd.c
+++ b/src/main/execute_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:30:10 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/19 15:45:31 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:33:05 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ bool	execute_simple_cmd(const t_simple_cmd scmd, int stdio_fd[2],
 		return (chpid != -1);
 	}
 	set_handlers_default();
-	close_fds_safely(&next_in_fd, 1);
+	close_fds_no_stdio(&next_in_fd, 1);
 	resolve_redirects(stdio_fd, reds);
 	path = get_path(words[0]);
 	// TODO: replace execvp to execve

--- a/src/main/init.c
+++ b/src/main/init.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:27:02 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/19 15:44:29 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:04:47 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,6 +24,7 @@
  */
 bool	init(void)
 {
+	rl_outstream = stderr;
 	set_handlers_for_process();
 	return (true);
 }

--- a/src/pipe/iterate_pipefd.c
+++ b/src/pipe/iterate_pipefd.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:24:19 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/17 04:41:19 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:33:10 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,14 +39,14 @@ bool	iterate_pipefd(bool is_first, bool is_last, int (*stdio)[2],
 	}
 	if (is_last)
 	{
-		close_fds_safely(*stdio, 2);
+		close_fds_no_stdio(*stdio, 2);
 		ft_memcpy(stdio, (int [2]){*next_in, STDOUT_FILENO}, sizeof(int [2]));
 		*next_in = STDIN_FILENO;
 		return (true);
 	}
 	if (pipe(pp_fd))
 		return (false);
-	close_fds_safely(*stdio, 2);
+	close_fds_no_stdio(*stdio, 2);
 	ft_memcpy(stdio, (int [2]){*next_in, pp_fd[1]}, sizeof(int [2]));
 	*next_in = pp_fd[0];
 	return (true);

--- a/src/redirect/resolve_redirects.c
+++ b/src/redirect/resolve_redirects.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:27:40 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/16 20:17:17 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:33:17 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ void	resolve_redirects(int stdio[2], t_redirect *red)
 {
 	dup2(stdio[0], STDIN_FILENO);
 	dup2(stdio[1], STDOUT_FILENO);
-	close_fds_safely(stdio, 2);
+	close_fds_no_stdio(stdio, 2);
 	// TODO: do redirect on red
 	free_redirects(red);
 }

--- a/src/utils/close_fds_no_stdio.c
+++ b/src/utils/close_fds_no_stdio.c
@@ -1,33 +1,37 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   close_fd_safely.c                                  :+:      :+:    :+:   */
+/*   close_fds_no_stdio.c                               :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:19:41 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/16 20:18:03 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/20 14:28:11 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
 /*
- * Function: close_fds_safely
+ * Function: 
  * ----------------------------
- * Close file descripters safely, this means not to close fd if it is a tty
+ * Close file descripters safely, this means not to close fd if it is stdio
  *
  * int fds: top pointer of file descriptors array
  * size_t size: array size of fds
  */
-void	close_fds_safely(int *fds, size_t size)
+void	close_fds_no_stdio(int *fds, size_t size)
 {
 	size_t	i;
 
 	i = 0;
 	while (i < size)
 	{
-		if (!isatty(fds[i]))
+		if (fds[i] == STDIN_FILENO
+			|| fds[i] == STDOUT_FILENO
+			|| fds[i] == STDERR_FILENO)
+			;
+		else
 			close(fds[i]);
 		i++;
 	}


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
bashと比較するテストを自動で行えるように
minishell起動時にfd0~2にリダイレクトのある場合の挙動と
minishellの出力先をbashに一致させた

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- readlineの出力先をstderrに変更
- fdをcloseする際、fdの数値がstdio(0~2の範囲内か)のものは除外するように変更（ttyか否かは無視）
- その関数の名称が明瞭ではなかったので変更

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->

fdをcloseする機能全般

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->
これをウィンドウ１で開いて
```sh
$ bash -i 1>/tmp/stdout 2>/tmp/stderr
```

これをウィンドウ２で開くと何がfd1で何がfd2に出力されるかわかる

```sh
$ watch -n 1 'echo "# stdout:"; tail /tmp/stdout; echo; echo "# stderr:"; tail /tmp/stderr;'
```

- テストケース1

stdout / stderrにリダイレクトを設定してコマンドを叩き
bashとminishellでfd1, fd2の内容がプロンプト以外一致していることを確認する
（ls, echo, wcなど）

```sh
$ bash -i 1>/tmp/stdout 2>/tmp/stderr
```

```sh
$ ./minishell 1>/tmp/stdout 2>/tmp/stderr
```

- テストケース2

stdin / stdout / stderrにリダイレクトを設定してコマンドを叩き
bashとminishellでfd1, fd2の内容がプロンプト以外一致していることを確認する

```sh
$ echo "ls | wc -l" | bash -i 1>/tmp/stdout 2>/tmp/stderr
```

```sh
$ echo "ls | wc -l" | ./minishell 1>/tmp/stdout 2>/tmp/stderr
```
