### PR TITLE
fix: debug/MakefileでreadlineのPATHを動的に取得するよう修正

### DIFF
--- a/debug/Makefile
+++ b/debug/Makefile
@@ -3,15 +3,15 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+         #
+#    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/02/22 18:57:59 by tkondo           ###   ########.fr        #
+#    Updated: 2025/02/23 18:36:34 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 ROOT_DIR = ..
-RL_DIR = /usr/local/Cellar/readline/8.2.13
+RL_DIR = $(shell brew --prefix readline)
 
 NAME = minishell.debug.o
 CC = cc


### PR DESCRIPTION
debugのためにmakeした際に、コンパイルエラーが出たため、RL_DIRの内容を修正

- エラー内容
```bash
../src/read/flush_prompt.c:24:2: error: call to undeclared function 'rl_replace_line'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
   24 |         rl_replace_line("", 0);
      |         ^
1 error generated.
make[1]: *** [../bin/read/flush_prompt.debug.o] Error 1
make: *** [lldb] Error 2
```


```Makefile
RL_DIR = $(shell brew --prefix readline)
```
