### PR TITLE
fix: free_words関数内で引数の先頭ポインターをfreeできていないバグを修正

### DIFF
--- a/src/data/free_simple_cmds.c
+++ b/src/data/free_simple_cmds.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:32:33 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/22 18:19:55 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/25 02:23:18 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,6 @@ void	free_simple_cmds(t_simple_cmd *scmds)
 	{
 		tmp = scmds;
 		free_words(scmds->words);
-		free(scmds->words);
 		free_redirects(scmds->reds);
 		scmds = scmds->next;
 		free(tmp);

--- a/src/data/free_words.c
+++ b/src/data/free_words.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:26:32 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/24 13:53:07 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/25 02:19:15 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,28 @@
  */
 void	free_words(char **words)
 {
+	int	i;
+
+	i = 0;
 	if (words == NULL)
 		return ;
-	while (*words)
+	while (words[i])
 	{
-		free(*words);
-		words++;
+		free(words[i]);
+		i++;
 	}
-	//ToDO:wordsの先頭をfreeする
+	free(words);
+}
+
+int	main(int argc, char **argv, char **envp)
+{
+	(void)argc;
+	(void)argv;
+	(void)envp;
+
+	char *t = "12345 67890";
+	char **e = ft_split(t, ' ');
+	free_words(e);
+	// free(e);
+	return (0);
 }

--- a/src/data/free_words.c
+++ b/src/data/free_words.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:26:32 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/25 02:19:15 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/25 02:23:46 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,17 +30,4 @@ void	free_words(char **words)
 		i++;
 	}
 	free(words);
-}
-
-int	main(int argc, char **argv, char **envp)
-{
-	(void)argc;
-	(void)argv;
-	(void)envp;
-
-	char *t = "12345 67890";
-	char **e = ft_split(t, ' ');
-	free_words(e);
-	// free(e);
-	return (0);
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:04:20 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/25 02:17:52 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/19 15:46:41 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,20 +14,20 @@
 
 volatile unsigned char	g_signal = 0;
 
-// int	main(int argc, char **argv, char **envp)
-// {
-// 	char			*input;
-// 	unsigned char	last_status;
+int	main(int argc, char **argv, char **envp)
+{
+	char			*input;
+	unsigned char	last_status;
 
-// 	(void)argc;
-// 	(void)argv;
-// 	init();
-// 	while (true)
-// 	{
-// 		input = get_input();
-// 		last_status = eval_text(input, envp);
-// 		set_exit_status(last_status);
-// 		free(input);
-// 	}
-// 	return (0);
-// }
+	(void)argc;
+	(void)argv;
+	init();
+	while (true)
+	{
+		input = get_input();
+		last_status = eval_text(input, envp);
+		set_exit_status(last_status);
+		free(input);
+	}
+	return (0);
+}

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:04:20 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/19 15:46:41 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/25 02:17:52 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,20 +14,20 @@
 
 volatile unsigned char	g_signal = 0;
 
-int	main(int argc, char **argv, char **envp)
-{
-	char			*input;
-	unsigned char	last_status;
+// int	main(int argc, char **argv, char **envp)
+// {
+// 	char			*input;
+// 	unsigned char	last_status;
 
-	(void)argc;
-	(void)argv;
-	init();
-	while (true)
-	{
-		input = get_input();
-		last_status = eval_text(input, envp);
-		set_exit_status(last_status);
-		free(input);
-	}
-	return (0);
-}
+// 	(void)argc;
+// 	(void)argv;
+// 	init();
+// 	while (true)
+// 	{
+// 		input = get_input();
+// 		last_status = eval_text(input, envp);
+// 		set_exit_status(last_status);
+// 		free(input);
+// 	}
+// 	return (0);
+// }


### PR DESCRIPTION

## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
free_words関数のバグを修正。

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
引数(char **words)の先頭をfreeしていないバグを修正しました。
上記のバグにより処理を追加していたfree_simple_cmds関数も、修正

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
free_words関数を利用している&引数の先頭をfree_words関数とは別でfreeしている場合、後者の処理は必要無くなったので、削除して大丈夫です。


## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->
mian関数を下記に書き換えて、free(e)のコメントアウトを外すとエラーがでる。このため、char **e の先頭もfreeできていることを確認できる。

```c
int	main(int argc, char **argv, char **envp)
{
	(void)argc;
	(void)argv;
	(void)envp;

	char *t = "12345 67890";
	char **e = ft_split(t, ' ');
	free_words(e);
	// free(e);
	return (0);
}
```
- 実行結果 
 ```bash
./minishell
minishell(7435,0x1ebdb4240) malloc: Double free of object 0x14de06040
minishell(7435,0x1ebdb4240) malloc: *** set a breakpoint in malloc_error_break to debug
zsh: abort      ./minishell
```