### PR TITLE
feat: heredocのプロンプトと一時ファイルへの書き込み機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 # System files
 .DS_Store
 *.swp
+/tags
 
 # Binary files
 minishell
 *.a
 *.o
+*.dSYM
 
 # Work directories
 /tkondo

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/02/24 14:49:09 by miyuu            ###   ########.fr        #
+#    Updated: 2025/02/27 14:41:26 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -56,6 +56,9 @@ TARGET =\
 	pipe/wait_status\
 	read/flush_prompt\
 	read/get_input\
+	read/write_heredocs\
+	read/write_until_eof\
+	read/write_until_eof_on_chproc\
 	redirect/resolve_redirects\
 	redirect/connect_redirects_path\
 	redirect/redirects_stdin\
@@ -66,6 +69,7 @@ TARGET =\
 	signal/set_handlers_for_prompt\
 	signal/set_handlers_default\
 	signal/set_handlers_for_process\
+	signal/set_handlers_for_heredoc\
 	signal/set_signal\
 
 OBJS = $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(TARGET)))

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -6,10 +6,9 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/02/26 12:37:37 by tkondo           ###   ########.fr        #
+#    Updated: 2025/02/27 14:32:41 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
-
 ROOT_DIR = ..
 RL_DIR = $(shell brew --prefix readline)
 
@@ -17,7 +16,7 @@ NAME = minishell.debug.o
 LIB_DEBUG = libdebug.a
 LIB_FT = $(ROOT_DIR)/libft/libft.a
 CC = cc
-AR = ar rcs
+AR = ar
 CFLAGS = \
 	-O0 \
 	-g \
@@ -39,18 +38,21 @@ SRC_EXT = .c
 OBJ_EXT = .debug.o
 SRCS = $(wildcard $(SRC_DIR)/*/*$(SRC_EXT))
 OBJS = $(SRCS:$(SRC_DIR)/%$(SRC_EXT)=$(OBJ_DIR)/%$(OBJ_EXT))
+OBJ_MAIN = $(OBJ_DIR)/main/main$(OBJ_EXT)
 
 ARG := $(word 2,$(MAKECMDGOALS))
 
 all: $(NAME) #Compile target with debug options
 
 $(NAME): $(LIB_FT) $(LIB_DEBUG)
-	$(CC) -L. -ldebug $(OBJ_DIR)/main/main$(OBJ_EXT) -o $(NAME) $(LIB_DIR) $(LFLAGS)
+	$(CC) -L. -ldebug $(OBJ_MAIN) -o $(NAME) $(LIB_DIR) $(LFLAGS)
 
 run-main: $(LIB_FT) $(LIB_DEBUG) #Compile and run by selecting file contain main
 ifeq ($(strip $(ARG)),)
 	@make run
 else
+	$(AR) rcs $(LIB_DEBUG) $(OBJ_MAIN)
+	$(AR) -d $(LIB_DEBUG) $(OBJ_MAIN)
 	$(CC) $(ARG) -o /tmp/$(basename $(notdir $(ARG)))$(OBJ_EXT) $(CFLAGS) $(LFLAGS) -L. -ldebug
 	/tmp/$(basename $(notdir $(ARG)))$(OBJ_EXT)
 endif
@@ -59,7 +61,7 @@ $(LIB_FT):
 	@make -C $(ROOT_DIR)/libft
 
 $(LIB_DEBUG): $(OBJS)
-	$(AR) $@ $?
+	$(AR) rcs $@ $?
 
 $(OBJ_DIR)/%$(OBJ_EXT): $(SRC_DIR)/%$(SRC_EXT)
 	@mkdir -p $(dir $@)

--- a/debug/main/test_write_heredocs.c
+++ b/debug/main/test_write_heredocs.c
@@ -6,21 +6,53 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 12:39:47 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/26 12:39:50 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/27 14:34:20 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
+volatile unsigned char g_signal = 0;
+
+void	print_hd_list(t_heredoc *hd_list)
+{
+	while (hd_list)
+	{
+		printf("hd_eof: \"%s\", path: \"%s\"\n", hd_list->eof, hd_list->path);
+		hd_list = hd_list->next;
+	}
+}
+
 int	main(void)
 {
-	t_heredoc	*hd;
+	t_heredoc	*root_hd;
+	t_heredoc	*cur_hd;
+	char		*hd_texts[4][2] = {
+		{"EOF", "/tmp/eof"},
+		{"AIUEO", "/tmp/aiueo"},
+		{"EOF", "/tmp/eof2"},
+		{NULL}
+	};
+	size_t		i;
 
-	hd = (t_heredoc *)malloc(sizeof(t_heredoc));
-	*hd = (t_heredoc){"EOF", "/tmp/eof", NULL};
-	hd->next = (t_heredoc *)malloc(sizeof(t_heredoc));
-	*(hd->next) = (t_heredoc){"AIUEO", "/tmp/aiueo", NULL};
-	hd->next->next = (t_heredoc *)malloc(sizeof(t_heredoc));
-	*(hd->next->next) = (t_heredoc){"EOF", "/tmp/eof2", NULL};
-	return (write_heredocs(hd));
+	i = 0;
+	root_hd = NULL;
+	while (hd_texts[i][0])
+	{
+		if (root_hd == NULL)
+		{
+			root_hd = (t_heredoc *)malloc(sizeof(t_heredoc));
+			*root_hd = (t_heredoc){hd_texts[i][0], hd_texts[i][1], NULL};
+			cur_hd = root_hd;
+		}
+		else
+		{
+			cur_hd->next = (t_heredoc *)malloc(sizeof(t_heredoc));
+			*(cur_hd->next) = (t_heredoc){hd_texts[i][0], hd_texts[i][1], NULL};
+			cur_hd = cur_hd->next;
+		}
+		i++;
+	}
+	print_hd_list(root_hd);
+	printf("returned: %d\n", write_heredocs(root_hd));
 }

--- a/debug/scripts/extract-signature.sh
+++ b/debug/scripts/extract-signature.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+DEBUG_FILE="${DEBUG_FILE-/dev/null}"
+SRC_DIR="src"
+
+show-mother-branch()
+{
+    local EXIT
+    git show-branch | grep '*' | grep -v "$(git rev-parse --abbrev-ref HEAD)" | head -1 | awk -F'[]~^[]' '{print $2}'
+    return "$?"
+}
+
+new-files-from-branch()
+{
+    local BRANCH="${1-$(show-mother-branch)}"
+
+    local COMMITED_NEW_FILES="$(git diff $BRANCH --name-status | grep -E '^A' | awk '{print $2}')"
+    local UNTRACKED_FILES="$(git status -s | grep -E '^\?\? ' | awk '{print $2}')"
+    printf "%s\n%s" "$UNTRACKED_FILES" "$COMMITED_NEW_FILES"
+    return "$?"
+}
+
+extract-signature()
+{
+    local SOURCE="$@"
+
+    cat $SOURCE | grep -E '^{' -B 1 | grep -v { | grep -v '\-\-' | awk '{print $0";"}'
+}
+
+main()
+{
+    set -e
+    echo "Run ${0##*/} on bash $BASH_VERSION" > "$DEBUG_FILE"
+    # ここに処理を追加
+    local NEW_FILES="${@-$(new-files-from-branch)}"
+    local C_FILES="$(find $NEW_FILES -type f | grep -E '^'"$SRC_DIR"'/.*\.c$')"
+    echo "extract signature from: $C_FILES" > "$DEBUG_FILE"
+    extract-signature "$C_FILES"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/debug/scripts/my-norm.sh
+++ b/debug/scripts/my-norm.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ROOT_DIR="$(git -C "${0%/*}" rev-parse --show-toplevel)"
+DEBUG_FILE="${DEBUG_FILE-/dev/null}"
+
+main()
+{
+    set -e
+    echo "Run ${0##*/} on bash $BASH_VERSION" > "$DEBUG_FILE"
+    # ここに処理を追加
+    cd "$ROOT_DIR"
+    local Error=0
+    while IFS= read line; do
+        if [ "$(echo $line | awk -F':' '{print $1}')" != "Error" ]; then
+            local FILE="$(echo $line | awk -F':' '{print $1}')"
+            local STATUS="$(echo $line | awk -F':' '{print $2}')"
+            local HEAD="$line"
+        else
+            if [ ! -z "$HEAD" ]; then
+                echo "$HEAD"
+            fi
+            local HEAD=""
+            echo "$line"
+            local Error=1
+        fi
+    done <<<$(norminette src/*/*.c include/*.h | grep Error | grep -v WRONG_SCOPE_COMMENT | grep -v LINE_TOO_LONG | grep -v TOO_MANY_LINES)
+    if [ "$Error" -eq 0 ]; then
+        echo "OK!"
+        exit 0
+    else
+        exit 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/24 16:58:15 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/27 14:18:00 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 
 /* header file*/
 # include <ft_stdio.h>
+# include <ft_string.h>
 # include <libft.h>
 
 /* library */
@@ -33,6 +34,7 @@
 /* macro */
 # define PROMPT "minishell$ "
 # define SHELL_NAME "minishell: "
+# define ERR_HEREDOC "%swarning: here-document delimited by end-of-file (wanted `%s')\n"
 
 /* struct */
 typedef struct s_simple_cmd		t_simple_cmd;
@@ -103,7 +105,6 @@ unsigned char	eval_text(const char *text, char **envp);
 bool			execute_simple_cmd(const t_simple_cmd *scmd, int stdio_fd[2], \
 				int next_in_fd, char **envp);
 bool			init(void);
-int				main(int argc, char **argv, char **envp);
 
 /* pipe function */
 bool			iterate_pipefd(bool is_first, bool is_last, int (*stdio)[2], \
@@ -113,6 +114,9 @@ unsigned char	wait_status(void);
 /* read function */
 void			flush_prompt(void);
 char			*get_input(void);
+void			write_until_eof(int fd, const char *hd_eof);
+bool			write_until_eof_on_chproc(int fd, const char *hd_eof);
+bool			write_heredocs(t_heredoc *hd);
 
 /* redirect function */
 void			connect_redirects_path(t_redirect *red);
@@ -125,6 +129,7 @@ void			at_sigint(int signal);
 void			set_handlers_default(void);
 void			set_handlers_for_process(void);
 void			set_handlers_for_prompt(void);
+void			set_handlers_for_heredoc(void);
 void			set_signal(int signal);
 
 /* utils */

--- a/src/main/eval_pipe.c
+++ b/src/main/eval_pipe.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:33:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/24 01:41:03 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/27 14:51:51 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,10 +26,15 @@ unsigned char	eval_pipe(const char *text, char **envp)
 	t_simple_cmd		*cur;
 	int					stdio_fd[2];
 	int					next_in_fd;
+	t_heredoc			*hd_list;
 
 	//ToDo:fill_struct_simple_cmdにheredocも渡す。fill_struct_simple_cmd(text, &scmd_list, &hd_list);になる
 	scmd_list = fill_struct_simple_cmd(text);
+	hd_list = NULL;
 	//ToDo:ヒアドクの入力を取得する処理を追加
+	if (!write_heredocs(hd_list))
+		return (0);
+	//TODO: free_heredoc(hd_list);
 	stdio_fd[0] = STDIN_FILENO;
 	stdio_fd[1] = STDOUT_FILENO;
 	next_in_fd = STDIN_FILENO;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:04:20 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/19 15:46:41 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/25 14:50:32 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,8 @@ int	main(int argc, char **argv, char **envp)
 	{
 		input = get_input();
 		last_status = eval_text(input, envp);
+		if (g_signal)
+			last_status = 128 + g_signal;
 		set_exit_status(last_status);
 		free(input);
 	}

--- a/src/read/write_heredocs.c
+++ b/src/read/write_heredocs.c
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   write_heredocs.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/02/26 16:18:21 by tkondo            #+#    #+#             */
+/*   Updated: 2025/02/27 14:39:48 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  write heredocs by using hd_list info
+ *
+ * Returns false if falure on write heredocs, otherwise true
+ * TODO: エラー出力
+ */
+bool	write_heredocs(t_heredoc *hd_list)
+{
+	int	fd;
+
+	if (hd_list == NULL)
+		return (true);
+	while (hd_list != NULL)
+	{
+		fd = open(hd_list->path, O_WRONLY | O_TRUNC | O_CREAT, 0644);
+		if (fd == -1)
+			return (false);
+		if (!write_until_eof_on_chproc(fd, hd_list->eof))
+		{
+			close(fd);
+			return (false);
+		}
+		if (close(fd) == -1)
+			return (false);
+		hd_list = hd_list->next;
+	}
+	return (true);
+}

--- a/src/read/write_until_eof.c
+++ b/src/read/write_until_eof.c
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   write_until_eof.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/02/26 16:18:21 by tkondo            #+#    #+#             */
+/*   Updated: 2025/02/27 13:33:17 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  read input and write it on given fd until it is hd_eof or empty line
+ *
+ * fd: file descriptor to write
+ * hd_eof: string represent end
+ */
+void	write_until_eof(int fd, const char *hd_eof)
+{
+	char	*line;
+	t_file	*file;
+
+	file = ft_fd2file(fd);
+	while (true)
+	{
+		line = readline("> ");
+		if (line == NULL)
+		{
+			ft_fprintf(ft_stderr(), ERR_HEREDOC, SHELL_NAME, hd_eof);
+			break ;
+		}
+		if (ft_strcmp(line, hd_eof) == 0)
+			break ;
+		ft_fprintf(file, "%s\n", line);
+		free(line);
+	}
+	free(line);
+	free(file);
+}

--- a/src/read/write_until_eof_on_chproc.c
+++ b/src/read/write_until_eof_on_chproc.c
@@ -1,0 +1,47 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   write_until_eof_on_chproc.c                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/02/26 16:18:21 by tkondo            #+#    #+#             */
+/*   Updated: 2025/02/27 14:49:34 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  do write until eof on child process
+ *
+ * fd: file descriptor to write
+ * hd_eof: string represent end
+ *
+ * Returns false if receive SIGINT, otherwise true
+ */
+bool	write_until_eof_on_chproc(int fd, const char *hd_eof)
+{
+	pid_t	pid;
+	int		stat;
+
+	pid = fork();
+	if (pid == -1)
+		return (false);
+	if (pid == 0)
+	{
+		set_handlers_for_heredoc();
+		write_until_eof(fd, hd_eof);
+		exit(0);
+	}
+	waitpid(pid, &stat, 0);
+	set_handlers_for_process();
+	if (WIFSIGNALED(stat) && WTERMSIG(stat) == SIGINT)
+	{
+		g_signal = WTERMSIG(stat);
+		return (false);
+	}
+	return (true);
+}

--- a/src/signal/set_handlers_for_heredoc.c
+++ b/src/signal/set_handlers_for_heredoc.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   at_sigint.c                                        :+:      :+:    :+:   */
+/*   set_handlers_for_heredoc.c                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/02/16 20:45:42 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/25 14:52:46 by tkondo           ###   ########.fr       */
+/*   Created: 2025/02/19 14:27:06 by tkondo            #+#    #+#             */
+/*   Updated: 2025/02/27 14:13:06 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,12 +15,10 @@
 /*
  * Function:
  * ----------------------------
- *  do when catch sigint on prompt
+ *  during waiting user input, kill prompt on SIGINT
  */
-void	at_sigint(int signal)
+void	set_handlers_for_heredoc(void)
 {
-	(void)signal;
-	g_signal = signal;
-	set_exit_status(signal + 128);
-	flush_prompt();
+	signal(SIGINT, SIG_DFL);
+	signal(SIGQUIT, SIG_IGN);
 }


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->

heredocのプロンプトと一時ファイルへの書き込み機能を追加した

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- eval_pipe関数でwrite_heredocs関数を呼びだすようにした
- promptでSIGINT時にg_signalと終了ステータスを変更するようにした
- make run-mainができないバグを修正
- ./debug/my-norm.shで必要なnorminetteエラーだけ表示できるようにした
- ./debug/extract-signature.shで親ディレクトリから追加されたソースのプロトタイプを抽出して表示できるようにした（複数行は未対応）

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->

既存機能への影響なし

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```sh
make -C debug run-main main/test_write_heredocs.c
```

debug/main/test_write_heredocs.cのhd_textsを変更してhd_eof, pathを変更してテスト可能

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

なし

## TODO

heredocにSIGINTが来た場合の終了ステータスについて実装したがちょっと不安
parseができるようになったらテストする