### PR TITLE
Chore: char型の2次元配列である`ecmd`と`scmd`の末尾に`s`をつけた

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/02/27 19:02:34 by tkondo           ###   ########.fr        #
+#    Updated: 2025/02/28 18:12:49 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -35,15 +35,15 @@ TARGET =\
 	data/free_simple_cmds\
 	data/add_struct_heredoc\
 	data/free_heredocs\
-	data/free_ecmd\
+	data/free_ecmds\
 	data/has_redirect\
-	data/fill_ecmd\
+	data/fill_ecmds\
 	data/add_struct_redirect\
 	data/parse_redirects\
 	data/fill_struct_simple_cmd\
 	data/load_simple_cmd\
 	data/pipe2scmd_list\
-	expand/expand_ecmd\
+	expand/expand_ecmds\
 	expand/get_exit_status\
 	expand/get_exit_status_p\
 	expand/set_exit_status\

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 18:46:38 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/02/28 18:16:44 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,7 +50,7 @@ typedef enum e_redirect_type
 struct				s_simple_cmd
 {
 	t_redirect		*redir;
-	char			**ecmd;
+	char			**ecmds;
 	t_simple_cmd	*next;
 };
 
@@ -76,25 +76,25 @@ extern volatile unsigned char	g_signal;
 int				builtin_exit(char **argv);
 
 /* command function */
-const char		*get_path(const char *ecmd);
+const char		*get_path(const char *ecmds);
 
 /* data function */
 void			add_struct_heredoc(t_heredoc **hd, char *eof, char *path);
 void			add_struct_redirect(t_redirect **redir, int type, char *path);
 t_simple_cmd	*fill_struct_simple_cmd(char **scmd_texts);
-char			**fill_ecmd(char **src, int wc);
+char			**fill_ecmds(char **src, int wc);
 void			free_heredocs(t_heredoc *hd);
 void			free_redirects(t_redirect *redir);
 void			free_simple_cmds(t_simple_cmd *scmd_list);
-void			free_ecmd(char **ecmd);
+void			free_ecmds(char **ecmds);
 bool			has_redirect(char *scmd);
-t_simple_cmd	*load_simple_cmd(char **scmd);
+t_simple_cmd	*load_simple_cmd(char **scmds);
 void			parse_redirects(t_redirect **redir, t_heredoc **hd, \
 								char *scmd, char *path);
 t_simple_cmd	*pipe2scmd_list(const char *cmd_line);
 
 /* expand function */
-void			expand_ecmd(char **ecmd);
+void			expand_ecmds(char **ecmds);
 unsigned char	*get_exit_status_p(void);
 unsigned char	get_exit_status(void);
 void			set_exit_status(unsigned char st);

--- a/src/data/fill_ecmds.c
+++ b/src/data/fill_ecmds.c
@@ -13,21 +13,21 @@
 #include <minishell.h>
 
 /*
- * Function:fill_ecmd
+ * Function:fill_ecmds
  * ----------------------------
  * Returns an array only strings without redirects.
  * ToDO:norminetteエラー
  */
-char	**fill_ecmd(char **src, int wc)
+char	**fill_ecmds(char **src, int wc)
 {
-	char	**ecmd;
+	char	**ecmds;
 	int		i;
 	int		j;
 
 	i = 0;
 	j = 0;
-	ecmd = (char **)malloc(sizeof(char *) * (wc + 1));
-	if (!ecmd)
+	ecmds = (char **)malloc(sizeof(char *) * (wc + 1));
+	if (!ecmds)
 		return (NULL);
 	while (src[i])
 	{
@@ -35,16 +35,16 @@ char	**fill_ecmd(char **src, int wc)
 			i++;
 		else
 		{
-			ecmd[j] = ft_strdup(src[i]);
-			if (!ecmd[j])
+			ecmds[j] = ft_strdup(src[i]);
+			if (!ecmds[j])
 			{
-				free_ecmd(ecmd);
+				free_ecmds(ecmds);
 				return (NULL);
 			}
 			j++;
 		}
 		i++;
 	}
-	ecmd[j] = NULL;
-	return (ecmd);
+	ecmds[j] = NULL;
+	return (ecmds);
 }

--- a/src/data/free_ecmds.c
+++ b/src/data/free_ecmds.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   free_ecmd.c                                       :+:      :+:    :+:   */
+/*   free_ecmd.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:26:32 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/26 11:40:03 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/28 18:07:43 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,19 +15,19 @@
 /*
  * Function:
  * ----------------------------
- * free memory of ecmd
+ * free memory of ecmds
  */
-void	free_ecmd(char **ecmd)
+void	free_ecmds(char **ecmds)
 {
 	int	i;
 
 	i = 0;
-	if (ecmd == NULL)
+	if (ecmds == NULL)
 		return ;
-	while (ecmd[i])
+	while (ecmds[i])
 	{
-		free(ecmd[i]);
+		free(ecmds[i]);
 		i++;
 	}
-	free(ecmd);
+	free(ecmds);
 }

--- a/src/data/free_simple_cmds.c
+++ b/src/data/free_simple_cmds.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:32:33 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 14:45:51 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/28 18:08:05 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ void	free_simple_cmds(t_simple_cmd *scmd_list)
 	while (scmd_list)
 	{
 		tmp = scmd_list;
-		free_ecmd(scmd_list->ecmd);
+		free_ecmds(scmd_list->ecmds);
 		free_redirects(scmd_list->redir);
 		scmd_list = scmd_list->next;
 		free(tmp);

--- a/src/data/load_simple_cmd.c
+++ b/src/data/load_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:28:21 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 14:41:16 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/28 18:17:17 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,10 +17,10 @@
  * ----------------------------
  *
  * Parses a simple command and returns a t_simple_cmd
- * containing redirections and ecmd.
+ * containing redirections and ecmds.
  *
  */
-t_simple_cmd	*load_simple_cmd(char **scmd)
+t_simple_cmd	*load_simple_cmd(char **scmds)
 {
 	size_t				i;
 	size_t				wc;
@@ -31,30 +31,30 @@ t_simple_cmd	*load_simple_cmd(char **scmd)
 	scmd_list = malloc(sizeof(t_simple_cmd));
 	if (!scmd_list)
 	{
-		free(scmd);
+		free(scmds);
 		return (NULL);
 	}
 	scmd_list->redir = NULL;
 	scmd_list->next = NULL;
 	i = 0;
 	wc = 0;
-	while (scmd[i])
+	while (scmds[i])
 	{
-		if (has_redirect(scmd[i]) && scmd[i + 1])
+		if (has_redirect(scmds[i]) && scmds[i + 1])
 		{
-			parse_redirects(&scmd_list->redir, hd, scmd[i], scmd[i + 1]);
+			parse_redirects(&scmd_list->redir, hd, scmds[i], scmds[i + 1]);
 			i++;
 		}
 		else
 			wc++;
 		i++;
 	}
-	scmd_list->ecmd = fill_ecmd(scmd, wc);
-	if (!scmd_list->ecmd)
+	scmd_list->ecmds = fill_ecmds(scmds, wc);
+	if (!scmd_list->ecmds)
 	{
-		free(scmd);
+		free(scmds);
 		return (NULL);
 	}
-	free(scmd);
+	free(scmds);
 	return (scmd_list);
 }

--- a/src/expand/expand_ecmds.c
+++ b/src/expand/expand_ecmds.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   expand_ecmd.c                                     :+:      :+:    :+:   */
+/*   expand_ecmd.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:29:00 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/26 11:40:50 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/28 18:08:22 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,13 +15,13 @@
 /*
  * Function:
  * ----------------------------
- * Expand ecmd and replace them
+ * Expand ecmds and replace them
  *
- * char ***ecmd: pointer to ecmd to be expand and replaced
+ * char ***ecmds: pointer to ecmds to be expand and replaced
  */
-void	expand_ecmd(char **ecmd)
+void	expand_ecmds(char **ecmds)
 {
 	// TODO: expand environment variables
 	// TODO: remove quotes
-	(void)ecmd;
+	(void)ecmds;
 }

--- a/src/main/execute_simple_cmd.c
+++ b/src/main/execute_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:30:10 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 14:51:44 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/02/28 18:08:46 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,21 +28,21 @@ bool	execute_simple_cmd(const t_simple_cmd *scmd_list, int stdio_fd[2],
 	const char	*path;
 	int			chpid;
 
-	expand_ecmd(scmd_list->ecmd);
+	expand_ecmds(scmd_list->ecmds);
 	chpid = fork();
 	if (chpid)
 	{
 		free_redirects(scmd_list->redir);
-		free_ecmd(scmd_list->ecmd);
+		free_ecmds(scmd_list->ecmds);
 		return (chpid != -1);
 	}
 	set_handlers_default();
 	close_fds_no_stdio(&next_in_fd, 1);
 	resolve_redirects(stdio_fd, scmd_list->redir);
 	// ToDo:e_cmd[0]がnullだった場合の処理を考える
-	path = get_path(scmd_list->ecmd[0]);
+	path = get_path(scmd_list->ecmds[0]);
 	// TODO: replace execvp to execve
-	execvp(path, scmd_list->ecmd);
+	execvp(path, scmd_list->ecmds);
 	(void)envp;
 	exit(1);
 }


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
下記にそれぞれ変更した。
- `char **ecmd` → `char **ecmds`
- `char **scmd` → `char **scmds`
 
char型であっても、1次元配列であれば`char *ecmd` or `char *ecmd`のままにしています。

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
`ecmd`と`scmd`を使用している関数。