### PR TITLE
Feat: リダイレクト記号の左側の数字に、リダイレクトを繋げる機能を追加

### DIFF
--- a/debug/test-cases/redirect.txt
+++ b/debug/test-cases/redirect.txt
@@ -1,16 +1,46 @@
 /bin/echo 42 Tokyo > /tmp/file1
 < /tmp/file1 cat
+
 < /tmp/file1 cat | grep 42 > /tmp/file2
 < /tmp/file2 cat
+
 ls -l >> /tmp/file2
 < /tmp/file2 cat
+
 yes | head -c 10000 | wc -c > /tmp/file3
 < /tmp/file3 cat
+
 < /tmp/file2 cat | wc > /tmp/file4 >> /tmp/file5
 < /tmp/file4 cat
 < /tmp/file5 cat
+
+## 以下のテストケースは、bashとエラー分の先頭が異なる
 < /tmp/no_exist_file
 /bin/echo testcase_4 > /tmp/no_exist_file
 < /tmp/no_exist_file cat
+
 rm /tmp/no_exist_file
+rm /tmp/file1 /tmp/file2 /tmp/file3 /tmp/file4 /tmp/file5
+
+## 以下、リダイレクトの左に数字があるver
+/bin/echo 42 Tokyo 1>/tmp/file1
+cat /tmp/file1
+
+ls -0 2>/tmp/file2
+cat /tmp/file2
+
+ls iiii 2>>/tmp/file3
+cat /tmp/file3
+
+rm /tmp/file1
+yes | head -c 10000 > /tmp/file1 | wc -c 0< /tmp/file1 1> /tmp/file4 2> /tmp/file5
+cat /tmp/file4
+cat /tmp/file5
+
+/bin/echo 42 Tokyo 1>/tmp/file1
+0</tmp/file1 cat
+yes | head -c 10000 > /tmp/file1 | wc -c 0< /tmp/file1 1> /tmp/file4 2> /tmp/file5
+cat /tmp/file4
+cat /tmp/file5
+
 rm /tmp/file1 /tmp/file2 /tmp/file3 /tmp/file4 /tmp/file5

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/02 20:48:20 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 22:04:42 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -137,8 +137,8 @@ bool			write_heredocs(t_heredoc *hd);
 
 /* redirect function */
 void			connect_redirects_path(t_redirect *redir);
-int				redirects_stdin(t_redirect *redir);
-int				redirects_stdout(t_redirect *redir);
+void			redirects_stdin(t_redirect *redir);
+void			redirects_stdout(t_redirect *redir);
 void			resolve_redirects(int stdio[2], t_redirect *redir);
 
 /* signal function */

--- a/src/redirect/connect_redirects_path.c
+++ b/src/redirect/connect_redirects_path.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:13:07 by miyuu             #+#    #+#             */
-/*   Updated: 2025/02/27 16:13:19 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 22:04:14 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,9 @@
  */
 void	connect_redirects_path(t_redirect *redir)
 {
-	int			fd;
-
-	fd = 0;
 	if (redir->type == REDIR_IN)
-		fd = redirects_stdin(redir);
+		redirects_stdin(redir);
 	else if (redir->type == REDIR_OUT || \
 			redir->type == REDIR_APPEND)
-		fd = redirects_stdout(redir);
-	close(fd);
+		redirects_stdout(redir);
 }

--- a/src/redirect/redirects_stdin.c
+++ b/src/redirect/redirects_stdin.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:14:20 by miyuu             #+#    #+#             */
-/*   Updated: 2025/02/26 12:39:32 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 18:59:06 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,13 +19,15 @@
  */
 int	redirects_stdin(t_redirect *redir)
 {
-	int	fd;
+	int	oldfd;
+	int	newfd;
 
-	fd = 0;
-	fd = open(redir->path, O_RDWR);
-	if (fd == -1)
+	oldfd = 0;
+	newfd = redir->from_fd;
+	oldfd = open(redir->path, O_RDWR);
+	if (oldfd == -1)
 		perror_exit((char *)redir->path);
-	if (dup2(fd, STDIN_FILENO) < 0)
+	if (dup2(oldfd, newfd) < 0)
 		perror_exit(NULL);
-	return (fd);
+	return (oldfd);
 }

--- a/src/redirect/redirects_stdin.c
+++ b/src/redirect/redirects_stdin.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:14:20 by miyuu             #+#    #+#             */
-/*   Updated: 2025/03/02 18:59:06 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 22:02:27 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,19 +15,18 @@
 /*
  * Function:redirects_stdin
  * ----------------------------
- * Set stdin(0) to the fd of path.
+ * Set from_fd to the fd of path.
  */
-int	redirects_stdin(t_redirect *redir)
+void	redirects_stdin(t_redirect *redir)
 {
 	int	oldfd;
 	int	newfd;
 
-	oldfd = 0;
 	newfd = redir->from_fd;
-	oldfd = open(redir->path, O_RDWR);
+	oldfd = open(redir->path, O_RDONLY);
 	if (oldfd == -1)
 		perror_exit((char *)redir->path);
 	if (dup2(oldfd, newfd) < 0)
 		perror_exit(NULL);
-	return (oldfd);
+	close(oldfd);
 }

--- a/src/redirect/redirects_stdout.c
+++ b/src/redirect/redirects_stdout.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:13:32 by miyuu             #+#    #+#             */
-/*   Updated: 2025/03/02 18:58:19 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 22:03:47 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,13 @@
 /*
  * Function:redirects_stdout
  * ----------------------------
- * Set stdout(1) to the fd of path.
+ * Set from_fd to the fd of path.
  */
-int	redirects_stdout(t_redirect *redir)
+void	redirects_stdout(t_redirect *redir)
 {
 	int	oldfd;
 	int	newfd;
 
-	oldfd = 0;
 	if (redir->type == REDIR_OUT)
 	{
 		oldfd = open(redir->path, O_WRONLY | O_TRUNC | O_CREAT, 0644);
@@ -35,8 +34,10 @@ int	redirects_stdout(t_redirect *redir)
 		if (oldfd == -1)
 			perror_exit((char *)redir->path);
 	}
+	else
+		return ;
 	newfd = redir->from_fd;
 	if (dup2(oldfd, newfd) < 0)
 		perror_exit(NULL);
-	return (oldfd);
+	close(oldfd);
 }

--- a/src/redirect/redirects_stdout.c
+++ b/src/redirect/redirects_stdout.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:13:32 by miyuu             #+#    #+#             */
-/*   Updated: 2025/02/27 16:13:20 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/02 18:58:19 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,22 +19,24 @@
  */
 int	redirects_stdout(t_redirect *redir)
 {
-	int	fd;
+	int	oldfd;
+	int	newfd;
 
-	fd = 0;
+	oldfd = 0;
 	if (redir->type == REDIR_OUT)
 	{
-		fd = open(redir->path, O_WRONLY | O_TRUNC | O_CREAT, 0644);
-		if (fd == -1)
+		oldfd = open(redir->path, O_WRONLY | O_TRUNC | O_CREAT, 0644);
+		if (oldfd == -1)
 			perror_exit((char *)redir->path);
 	}
 	else if (redir->type == REDIR_APPEND)
 	{
-		fd = open(redir->path, O_WRONLY | O_APPEND | O_CREAT, 0644);
-		if (fd == -1)
+		oldfd = open(redir->path, O_WRONLY | O_APPEND | O_CREAT, 0644);
+		if (oldfd == -1)
 			perror_exit((char *)redir->path);
 	}
-	if (dup2(fd, STDOUT_FILENO) < 0)
+	newfd = redir->from_fd;
+	if (dup2(oldfd, newfd) < 0)
 		perror_exit(NULL);
-	return (fd);
+	return (oldfd);
 }


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
`t_redirect *redir`の`int from_fd`(リダイレクト記号の左側の数字)に、リダイレクトを繋げる処理を追加

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
- redirects_stdin関数とredirects_stdout関数内での`dup2()`で、`t_redirect *redir->from_fd`を使用した。
- debug/test-cases/redirect.txtにテストケースを追加した

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
特になし

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```bash
make -C debug test test-cases/redirect.txt
```