### PR TITLE
feat: 環境変数まわりのbuiltinを実行できるようにした（env, export, unset）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/03 17:59:29 by tkondo           ###   ########.fr        #
+#    Updated: 2025/03/03 18:31:47 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -35,6 +35,7 @@ TARGET =\
 	builtin/builtin_cd\
 	builtin/builtin_env\
 	builtin/builtin_export\
+	builtin/builtin_unset\
 	builtin/is_builtin\
 	command/get_path\
 	data/free_redirects\

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/03 13:17:15 by tkondo           ###   ########.fr        #
+#    Updated: 2025/03/03 17:59:29 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -34,6 +34,7 @@ TARGET =\
 	builtin/builtin_pwd\
 	builtin/builtin_cd\
 	builtin/builtin_env\
+	builtin/builtin_export\
 	builtin/is_builtin\
 	command/get_path\
 	data/free_redirects\
@@ -50,6 +51,9 @@ TARGET =\
 	data/fill_struct_simple_cmd\
 	data/load_simple_cmd\
 	data/pipe2scmd_list\
+	env/is_valid_identifier\
+	env/load_variable_assignment\
+	env/register_env\
 	expand/expand_ecmds\
 	expand/get_exit_status\
 	expand/get_exit_status_p\

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/02 16:27:55 by miyuu            ###   ########.fr        #
+#    Updated: 2025/03/03 13:17:15 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,6 +33,7 @@ TARGET =\
 	builtin/builtin_exit\
 	builtin/builtin_pwd\
 	builtin/builtin_cd\
+	builtin/builtin_env\
 	builtin/is_builtin\
 	command/get_path\
 	data/free_redirects\

--- a/debug/Makefile
+++ b/debug/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/01 18:20:50 by tkondo           ###   ########.fr        #
+#    Updated: 2025/03/03 12:49:05 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -149,7 +149,7 @@ $(OBJ_DIR)/%$(OBJ_EXT): $(SRC_DIR)/%$(SRC_EXT) $(INC_DEBUG)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@ $(INCLUDE_DIR)
 
-$(INC_DEBUG): $(SRCS)
+$(INC_DEBUG): $(SRCS) $(ROOT_DIR)/include/minishell.h
 	@mkdir -p $(dir $@)
 	@./scripts/exclude-prototype.pl $(ROOT_DIR)/include/minishell.h > $(INC_DEBUG).tmp
 	@./scripts/extract-prototype.pl $(ROOT_DIR)/src/*/*.c >> $(INC_DEBUG).tmp

--- a/debug/test-cases/env.txt
+++ b/debug/test-cases/env.txt
@@ -1,0 +1,1 @@
+env | sort | grep -v ^_=

--- a/debug/test-cases/export.txt
+++ b/debug/test-cases/export.txt
@@ -8,6 +8,7 @@ export = ooo=kkk
 
 env | sort | grep -v ^_=
 
+export aiueo=aiueo | env | sort | grep -v ^_=
 export =ft
 export == ===
 export ^=a

--- a/debug/test-cases/export.txt
+++ b/debug/test-cases/export.txt
@@ -1,0 +1,15 @@
+export ft=42
+export 42=FT
+export a==
+export B=b=
+export aaa=iii uuu=eee
+
+export = ooo=kkk
+
+env | sort | grep -v ^_=
+
+export =ft
+export == ===
+export ^=a
+export %=ft
+export === a=1

--- a/debug/test-cases/unset.txt
+++ b/debug/test-cases/unset.txt
@@ -1,0 +1,12 @@
+export V1=1
+unset V1
+env | grep V1
+
+export UNSET1=1 UNSET2= UNSET3=3
+unset UNSET1 UNSET2 UNSET3
+env | grep UNSET
+
+
+export V1=1
+echo | unset V1
+env | grep V1

--- a/debug/test.sh
+++ b/debug/test.sh
@@ -99,6 +99,7 @@ main()
         echo "  export MISH='/path/to/minishell'" >&2
         return 1
     fi
+    unset OLDPWD
     if [ -z "$1" ]; then
         test-files "$TESTCASE_DIR"
     elif [ -f "$1" ]; then

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 13:22:25 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 17:57:36 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@
 # include <string.h>
 # include <unistd.h>
 # include <fcntl.h>
+# include <errno.h>
 # include <readline/history.h>
 # include <readline/readline.h>
 # include <sys/types.h>
@@ -89,6 +90,7 @@ int				builtin_echo(char **argv);
 int				builtin_pwd(char **argv);
 int				builtin_cd(char **argv);
 int				builtin_env(char **argv);
+int				builtin_export(char **argv);
 
 /* command function */
 const char		*get_path(const char *ecmds);
@@ -110,6 +112,11 @@ t_simple_cmd	*load_simple_cmd(char **scmds);
 void			parse_redirects(t_redirect **redir, t_heredoc **hd, \
 								char *word, char *next_word);
 t_simple_cmd	*pipe2scmd_list(const char *cmd_line);
+
+/* env function */
+bool			is_valid_identifier(char *string);
+void			load_variable_assignment(char *string, char **name, char **value);
+bool			register_env(char *string);
 
 /* expand function */
 void			expand_ecmds(char **ecmds);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/02 22:04:42 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/03 13:22:25 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 /* header file*/
 # include <ft_stdio.h>
 # include <ft_string.h>
+# include <ft_stdlib.h>
 # include <libft.h>
 
 /* library */
@@ -87,6 +88,7 @@ int				builtin_exit(char **argv);
 int				builtin_echo(char **argv);
 int				builtin_pwd(char **argv);
 int				builtin_cd(char **argv);
+int				builtin_env(char **argv);
 
 /* command function */
 const char		*get_path(const char *ecmds);
@@ -120,7 +122,7 @@ unsigned char	eval_pipe(const char *cmd_line, char **envp);
 unsigned char	eval_cmd_line(const char *cmd_line, char **envp);
 bool			execute_simple_cmd(const t_simple_cmd *scmd_list, \
 				int stdio_fd[2], int next_in_fd, char **envp);
-bool			init(void);
+bool			init(char **envp);
 unsigned char	execute_on_current_env(char **ecmds, t_redirect *redir, char **envp);
 
 /* pipe function */

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 17:57:36 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 18:31:37 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,6 +91,7 @@ int				builtin_pwd(char **argv);
 int				builtin_cd(char **argv);
 int				builtin_env(char **argv);
 int				builtin_export(char **argv);
+int				builtin_unset(char **argv);
 
 /* command function */
 const char		*get_path(const char *ecmds);

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/01/04 15:21:37 by tkondo           ###   ########.fr        #
+#    Updated: 2025/03/03 12:20:34 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -84,6 +84,7 @@ TARGET =\
 	ft_fprintf\
 	ft_htbl0\
 	ft_htbl1\
+	ft_htbl2\
 	ft_blocked_node\
 	ft_memory\
 	ft_gmemory\
@@ -91,6 +92,7 @@ TARGET =\
 	ft_exit\
 	ft_env0\
 	ft_env1\
+	ft_env2\
 	ft_exec\
 	get_next_line\
 

--- a/libft/include/ft_htbl.h
+++ b/libft/include/ft_htbl.h
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/11 02:17:24 by tkondo            #+#    #+#             */
-/*   Updated: 2025/01/04 12:29:06 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 11:12:39 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -32,5 +32,7 @@ t_htbl					htget(t_htbl ht, const char *key);
 void					htdelone(t_htbl ht, const char *key,
 							void (*del)(t_htnode *));
 void					htclear(t_htbl ht, void (*del)(t_htnode *));
+void					htiter(t_htbl ht, void (*f)(t_htnode *, void *),
+							void *p);
 
 #endif

--- a/libft/include/ft_stdlib.h
+++ b/libft/include/ft_stdlib.h
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/04/27 19:52:48 by tkondo            #+#    #+#             */
-/*   Updated: 2025/01/04 11:47:12 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 11:31:05 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,6 @@ int		ft_putenv(char *string);
 int		ft_unsetenv(const char *name);
 int		ft_initenv(char **envp);
 void	ft_clearenv(void);
+char	**ft_getenvp(void);
 
 #endif

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -1,0 +1,72 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   libft.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42.fr>              +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/04/27 19:52:48 by tkondo            #+#    #+#             */
+/*   Updated: 2024/12/26 03:16:38 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef LIBFT_H
+
+# define LIBFT_H
+# include <stddef.h>
+# include <stdint.h>
+
+typedef struct s_list
+{
+	void			*content;
+	struct s_list	*next;
+}					t_list;
+
+int					ft_isalpha(int c);
+int					ft_isdigit(int c);
+int					ft_isalnum(int c);
+int					ft_isascii(int c);
+int					ft_isprint(int c);
+size_t				ft_strlen(const char *s);
+void				*ft_memset(void *b, int c, size_t len);
+void				ft_bzero(void *s, size_t n);
+void				*ft_memcpy(void *dst, const void *src, size_t n);
+void				*ft_memmove(void *dst, const void *src, size_t len);
+size_t				ft_strlcpy(char *dst, const char *src, size_t dstsize);
+size_t				ft_strlcat(char *dst, const char *src, size_t dstsize);
+int					ft_toupper(int c);
+int					ft_tolower(int c);
+char				*ft_strchr(const char *s, int c);
+char				*ft_strrchr(const char *s, int c);
+int					ft_strncmp(const char *s1, const char *s2, size_t n);
+void				*ft_memchr(const void *s, int c, size_t n);
+int					ft_memcmp(const void *s1, const void *s2, size_t n);
+char				*ft_strnstr(const char *haystack, const char *needle,
+						size_t len);
+int					ft_atoi(const char *str);
+void				*ft_calloc(size_t count, size_t size);
+char				*ft_strdup(const char *s1);
+char				*ft_substr(char const *s, unsigned int start, size_t len);
+char				*ft_strjoin(char const *s1, char const *s2);
+char				*ft_strtrim(char const *s1, char const *set);
+char				**ft_split(char const *s, char c);
+char				*ft_itoa(int n);
+char				*ft_strmapi(char const *s, char (*f)(unsigned int, char));
+void				ft_striteri(char *s, void (*f)(unsigned int, char *));
+void				ft_putchar_fd(char c, int fd);
+void				ft_putstr_fd(char *s, int fd);
+void				ft_putendl_fd(char *s, int fd);
+void				ft_putnbr_fd(int n, int fd);
+t_list				*ft_lstnew(void *content);
+void				ft_lstadd_front(t_list **lst, t_list *new);
+int					ft_lstsize(t_list *lst);
+t_list				*ft_lstlast(t_list *lst);
+void				ft_lstadd_back(t_list **lst, t_list *new);
+void				ft_lstdelone(t_list *lst, void (*del)(void *));
+void				ft_lstclear(t_list **lst, void (*del)(void *));
+void				ft_lstiter(t_list *lst, void (*f)(void *));
+t_list				*ft_lstmap(t_list *lst, void *(*f)(void *),
+						void (*del)(void *));
+char				*get_next_line(int fd);
+
+#endif

--- a/libft/src/ft_env1.c
+++ b/libft/src/ft_env1.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 11:19:40 by tkondo            #+#    #+#             */
-/*   Updated: 2025/01/04 12:22:18 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 17:25:31 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,13 +25,23 @@ char	*ft_getenv(const char *key)
 int	ft_setenv(const char *name, const char *value, int overwrite)
 {
 	t_htbl	*p;
+	char *dup_name;
+	char *dup_value;
 
 	if (!overwrite && ft_getenv(name) != NULL)
 		return (-1);
 	p = _getenvp();
 	if (p == NULL)
 		return (-1);
-	htadd(*p, name, (void *)value);
+	dup_name = ft_strdup(name);
+	dup_value = ft_strdup(value);
+	if (dup_name == NULL || dup_value == NULL)
+	{
+		free(dup_name);
+		free(dup_value);
+		return -1;
+	}
+	htadd(*p, dup_name, (void *)dup_value);
 	return (0);
 }
 

--- a/libft/src/ft_env2.c
+++ b/libft/src/ft_env2.c
@@ -1,0 +1,52 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_env2.c                                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 12:16:20 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 12:16:22 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <_ft_stdlib.h>
+
+static void	cnt_htnode(t_htnode *n, void *cntp)
+{
+	(void)n;
+	(*(size_t *)cntp)++;
+}
+
+static void	store_htnode(t_htnode *n, void *p)
+{
+	char	***envp_cur;
+	char	*keyval;
+
+	keyval = ft_strjoin((char *)n->key, "=");
+	keyval = ft_strjoin(keyval, (char *)n->val);
+	envp_cur = (char ***)p;
+	**envp_cur = keyval;
+	++*envp_cur;
+}
+
+char	**ft_getenvp(void)
+{
+	t_htbl	*p;
+	size_t	cnt;
+	char	**envp;
+	char	**envp_cur;
+
+	p = _getenvp();
+	if (p == NULL)
+		return (NULL);
+	cnt = 0;
+	htiter(*p, cnt_htnode, (void *)&cnt);
+	envp = malloc(sizeof(char *) * (cnt + 1));
+	if (!envp)
+		return (NULL);
+	envp[cnt] = NULL;
+	envp_cur = envp;
+	htiter(*p, store_htnode, (void *)&envp_cur);
+	return (envp);
+}

--- a/libft/src/ft_htbl2.c
+++ b/libft/src/ft_htbl2.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_htbl2.c                                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 12:18:31 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 12:18:33 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "ft_htbl.h"
+#include "ft_stdlib.h"
+#include "ft_string.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+void	htiter(t_htbl ht, void (*f)(t_htnode *, void *), void *p)
+{
+	int			h;
+	t_htnode	*node;
+	t_htnode	*_node;
+
+	h = 0;
+	while (h < HTSIZE)
+	{
+		node = ht[h];
+		while (node)
+		{
+			_node = node->next;
+			f(node, p);
+			node = _node;
+		}
+		h++;
+	}
+}

--- a/libft/test/ft_env.c
+++ b/libft/test/ft_env.c
@@ -6,11 +6,20 @@ int main(int argc, char *argv[], char *envp[])
 {
 	char **t;
 	t=envp;
+	ft_printf("----- envp -----\n");
 	while(*t)
 	{
-		printf("%s\n", *t);t++;
+		ft_printf("%s\n", *t);t++;
 	}
 	ft_initenv(envp);
+	ft_printf("----- PATH from ft_getenv -----\n");
 	ft_printf("%s\n", ft_getenv("PATH"));
+	t = ft_getenvp();
+	ft_printf("----- ft_getenvp -----\n");
+	while(t && *t)
+	{
+		ft_printf("%s\n", *t);
+		t++;
+	}
 	ft_exit(0);
 }

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/03 12:51:45 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 13:16:51 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 17:15:00 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,17 +20,19 @@
 int	builtin_env(char **argv)
 {
 	char	**envp;
+	char	**envp_bak;
 
 	(void)argv;
 	envp = ft_getenvp();
 	if (envp == NULL)
 		return (1);
+	envp_bak = envp;
 	while (*envp != NULL)
 	{
 		ft_printf("%s\n", *envp);
 		free(*envp);
 		envp++;
 	}
-	free(envp);
+	free(envp_bak);
 	return (0);
 }

--- a/src/builtin/builtin_env.c
+++ b/src/builtin/builtin_env.c
@@ -1,31 +1,36 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   init.c                                             :+:      :+:    :+:   */
+/*   builtin_env.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/02/16 20:27:02 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 13:21:42 by tkondo           ###   ########.fr       */
+/*   Created: 2025/03/03 12:51:45 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 13:16:51 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
 /*
- * Function:
+ * Function: builtin_env
  * ----------------------------
- * Do anything before starting shell such as:
- *   setup signal handler
- *   setup function do on exit
- *   ...
- *
- * Returns: false if any unexpected result will happen, otherwise true
+ *  show environment variables
  */
-bool	init(char **envp)
+int	builtin_env(char **argv)
 {
-	rl_outstream = stderr;
-	set_handlers_for_process();
-	ft_initenv(envp);
-	return (true);
+	char	**envp;
+
+	(void)argv;
+	envp = ft_getenvp();
+	if (envp == NULL)
+		return (1);
+	while (*envp != NULL)
+	{
+		ft_printf("%s\n", *envp);
+		free(*envp);
+		envp++;
+	}
+	free(envp);
+	return (0);
 }

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/21 18:33:01 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 22:30:38 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 14:18:48 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,5 +29,5 @@ int	builtin_exit(char **argv)
 	else
 		status = ft_atoi(argv[0]);
 	ft_fprintf(ft_stderr(), "exit\n");
-	exit(status);
+	ft_exit(status);
 }

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/21 18:33:01 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 14:18:48 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 18:09:02 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,4 +30,5 @@ int	builtin_exit(char **argv)
 		status = ft_atoi(argv[0]);
 	ft_fprintf(ft_stderr(), "exit\n");
 	ft_exit(status);
+	return (1);
 }

--- a/src/builtin/builtin_export.c
+++ b/src/builtin/builtin_export.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_export.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 17:07:28 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 18:09:49 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function: builtin_export
+ * ----------------------------
+ *
+ */
+int	builtin_export(char **argv)
+{
+	size_t	i;
+	bool	success;
+
+	i = 0;
+	// TODO: export用の表示に変更する
+	if (argv[i] == NULL)
+		return (builtin_env(NULL));
+	success = true;
+	while (argv[i] != NULL)
+	{
+		success = (register_env(argv[i]) && success);
+		i++;
+	}
+	return (!success);
+}

--- a/src/builtin/builtin_unset.c
+++ b/src/builtin/builtin_unset.c
@@ -1,0 +1,31 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   builtin_unset.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 18:29:39 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 18:30:33 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function: builtin_unset
+ * ----------------------------
+ *  unset environment varibales
+ */
+int	builtin_unset(char **argv)
+{
+	size_t	i;
+
+	i = 0;
+	while (argv[i])
+	{
+		ft_unsetenv(argv[i]);
+		i++;
+	}
+	return (0);
+}

--- a/src/env/is_valid_identifier.c
+++ b/src/env/is_valid_identifier.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   is_valid_identifier.c                              :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 17:53:53 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 17:53:57 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  check if is the given string valid as identifier
+ */
+bool	is_valid_identifier(char *string)
+{
+	if (string == NULL)
+		return (false);
+	if (!ft_isalpha(*string) && *string != '_')
+		return (false);
+	string++;
+	while (*string)
+	{
+		if (!ft_isalnum(*string) && *string != '_')
+			return (false);
+		string++;
+	}
+	return (true);
+}

--- a/src/env/load_variable_assignment.c
+++ b/src/env/load_variable_assignment.c
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   load_variable_assignment.c                         :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 17:54:33 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 17:54:42 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  load variable assignemnt string into name and value
+ */
+void	load_variable_assignment(char *string, char **name, char **value)
+{
+	char	*sep;
+
+	*name = NULL;
+	*value = NULL;
+	sep = ft_strchr(string, '=');
+	if (sep == NULL)
+		return ;
+	*name = ft_strndup(string, sep - string);
+	if (*name == NULL)
+		return ;
+	if (!is_valid_identifier(*name))
+	{
+		free(*name);
+		*name = NULL;
+		return ;
+	}
+	*value = ft_strdup(sep + 1);
+	if (*value == NULL)
+	{
+		free(*name);
+		*name = NULL;
+	}
+}

--- a/src/env/register_env.c
+++ b/src/env/register_env.c
@@ -1,0 +1,42 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   register_env.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/03 17:55:35 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/03 17:55:39 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:
+ * ----------------------------
+ *  manage applying variable assignment statament to env
+ */
+bool	register_env(char *string)
+{
+	char	*name;
+	char	*value;
+	bool	success;
+
+	load_variable_assignment(string, &name, &value);
+	if (name == NULL)
+	{
+		if (errno)
+			perror_exit(NULL);
+		else
+			ft_fprintf(ft_stderr(),
+				"bash: export: `%s': not a valid identifier\n", string);
+		return (false);
+	}
+	success = ft_setenv(name, value, true) != -1;
+	free(name);
+	free(value);
+	if (!success)
+		perror_exit(NULL);
+	return (success);
+}

--- a/src/main/execute_builtin.c
+++ b/src/main/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 22:45:22 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 12:52:09 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 17:15:37 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ unsigned char	execute_builtin(char **ecmds, char **envp)
 	if (ft_strcmp(*ecmds, "env") == 0)
 		return (builtin_env(ecmds + 1));
 	if (ft_strcmp(*ecmds, "export") == 0)
-		return (0);
+		return (builtin_export(ecmds + 1));
 	if (ft_strcmp(*ecmds, "unset") == 0)
 		return (0);
 	if (ft_strcmp(*ecmds, "pwd") == 0)

--- a/src/main/execute_builtin.c
+++ b/src/main/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 22:45:22 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 17:15:37 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 18:19:58 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ unsigned char	execute_builtin(char **ecmds, char **envp)
 	if (ft_strcmp(*ecmds, "export") == 0)
 		return (builtin_export(ecmds + 1));
 	if (ft_strcmp(*ecmds, "unset") == 0)
-		return (0);
+		return (builtin_unset(ecmds + 1));
 	if (ft_strcmp(*ecmds, "pwd") == 0)
 		return (builtin_pwd(ecmds + 1));
 	if (ft_strcmp(*ecmds, "cd") == 0)

--- a/src/main/execute_builtin.c
+++ b/src/main/execute_builtin.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/27 22:45:22 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/01 14:34:18 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 12:52:09 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ unsigned char	execute_builtin(char **ecmds, char **envp)
 	if (ft_strcmp(*ecmds, "echo") == 0)
 		return (builtin_echo(ecmds + 1));
 	if (ft_strcmp(*ecmds, "env") == 0)
-		return (0);
+		return (builtin_env(ecmds + 1));
 	if (ft_strcmp(*ecmds, "export") == 0)
 		return (0);
 	if (ft_strcmp(*ecmds, "unset") == 0)

--- a/src/main/execute_simple_cmd.c
+++ b/src/main/execute_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:30:10 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 14:17:57 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 18:09:24 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,4 +46,5 @@ bool	execute_simple_cmd(const t_simple_cmd *scmd_list, int stdio_fd[2],
 	execvp(path, scmd_list->ecmds);
 	(void)envp;
 	ft_exit(1);
+	return (false);
 }

--- a/src/main/execute_simple_cmd.c
+++ b/src/main/execute_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:30:10 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/28 18:47:58 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 14:17:57 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,10 +40,10 @@ bool	execute_simple_cmd(const t_simple_cmd *scmd_list, int stdio_fd[2],
 	resolve_redirects(stdio_fd, scmd_list->redir);
 	// ToDo:e_cmd[0]がnullだった場合の処理を考える
 	if (is_builtin(scmd_list->ecmds[0]))
-		exit(execute_builtin(scmd_list->ecmds, envp));
+		ft_exit(execute_builtin(scmd_list->ecmds, envp));
 	path = get_path(scmd_list->ecmds[0]);
 	// TODO: replace execvp to execve
 	execvp(path, scmd_list->ecmds);
 	(void)envp;
-	exit(1);
+	ft_exit(1);
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:04:20 by tkondo            #+#    #+#             */
-/*   Updated: 2025/02/27 18:47:16 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/03 13:22:09 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ int	main(int argc, char **argv, char **envp)
 
 	(void)argc;
 	(void)argv;
-	init();
+	init(envp);
 	while (true)
 	{
 		input = get_input();

--- a/src/utils/perror_exit.c
+++ b/src/utils/perror_exit.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/24 14:14:07 by miyuu             #+#    #+#             */
-/*   Updated: 2025/02/24 14:46:03 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/03 14:18:56 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,5 +21,5 @@ void	perror_exit(char *msg)
 {
 	write(2, SHELL_NAME, ft_strlen(SHELL_NAME));
 	perror(msg);
-	exit (1);
+	ft_exit (1);
 }


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
環境変数まわりのbuiltinを実行できるようにした（env, export, unset）
## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- feat: 環境変数まわりのbuiltinを実行できるようにした（env, export, unset）
  - export
  左辺(key)が英数字か_（1文字目は数字×）チェック、equalがあるかチェック（シェル変数からのexportがないので独自実装）
  複数の引数が来た場合、それぞれについてexportを行う。その場合、途中で誤った文字列が来ても終了せずに中断して次の引数を処理する
- build: ft_stdlibを追加してft_*env系の関数で環境変数の管理を簡単にできるようにした
- build: ft_envの終了処理のため、exitを全てft_exitに変更
- debug: デバッグビルドの際にinclude/minishell.hの変更を検知して更新するようにした

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->

初期化、終了処理

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->
```sh
make && ./debug/test.sh
```
- env
```sh
env | grep AAA
```
- export
```sh
export ft=42
export 42=FT
export a==
export B=b=
export aaa=iii uuu=eee

export = ooo=kkk

env | sort | grep -v ^_=

export aiueo=aiueo | env | sort | grep -v ^_=
export =ft
export == ===
export ^=a
export %=ft
export === a=1
```
- unset
```sh
export V1=1
unset V1
env | grep V1

export UNSET1=1 UNSET2= UNSET3=3
unset UNSET1 UNSET2 UNSET3
env | grep UNSET


export V1=1
echo | unset V1
env | grep V1

```
## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

## 留意点
- （重要）exitの際にft_atexitで登録した関数を実行させるため、exitの代わりにft_exitを用いる必要がある（関数名以外のシグネチャは同じ）
- envで表示される順がbashと異なる。機能的な問題が特に思い当たらないので一旦このままでいいかと。
- envで表示される_は実行中のコマンドの絶対パスとなるのでbashと異なる
- exportでシェル変数を環境変数にする処理は実装しないので、エラーを出すようにした
- 以下のexportのケースは変数展開とクオーと削除の実装完了後に対応する
```
export "FT=    ft"
export "FT= ft"
export FT =ft
```
- exportの引数なしの場合の表示の微調整は後で行う
- unsetのエラーハンドリングについて、readonlyの環境変数は今のところなさそうなのでハンドリングしていない