### PR TITLE
feat: リダイレクトpathを展開するようにした

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/18 12:58:29 by tkondo           ###   ########.fr        #
+#    Updated: 2025/03/19 17:21:50 by tkondo           ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -66,6 +66,7 @@ TARGET =\
 	data/handle_heredoc\
 	data/add_redir_list_last\
 	data/token2ecmds\
+	data/token2path\
 	env/is_valid_identifier\
 	env/load_variable_assignment\
 	env/register_env\

--- a/debug/test-cases/expand-redirect.txt
+++ b/debug/test-cases/expand-redirect.txt
@@ -1,0 +1,57 @@
+-- テスト用ディレクトリを作成
+export 'TMP_DIR=/tmp/test-expand-redirect'
+rm -r "$TMP_DIR"
+mkdir -p "$TMP_DIR"
+cd "$TMP_DIR"
+
+-- テスト1: 通常の変数の場合
+export VAR="variable"
+>$VAR
+echo $?
+ls
+>"$VAR"
+echo $?
+ls
+>'$VAR'
+echo $?
+ls
+
+-- テスト2: 変数の展開結果が複数になる場合
+export MUL="first second"
+>$MUL
+echo $?
+ls
+>"$MUL"
+echo $?
+ls
+>'$MUL'
+echo $?
+ls
+
+-- テスト3: 変数が空文字列の場合
+export EMPTY=
+>$EMPTY
+echo $?
+ls
+>"$EMPTY"
+echo $?
+ls
+>'$EMPTY'
+echo $?
+ls
+
+-- テスト4: 変数がsetされていない場合
+unset UNSET
+>$UNSET
+echo $?
+ls
+>"$UNSET"
+echo $?
+ls
+>'$UNSET'
+echo $?
+ls
+
+-- テスト用ディレクトリを削除
+cd -
+rm -r "$TMP_DIR"

--- a/debug/test-cases/expand-redirect.txt
+++ b/debug/test-cases/expand-redirect.txt
@@ -52,6 +52,10 @@ ls
 echo $?
 ls
 
+-- テスト5: 変数がset されていないかつpipeの途中
+unset UNSET
+echo | >$UNSET | echo
+
 -- テスト用ディレクトリを削除
 cd -
 rm -r "$TMP_DIR"

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/18 12:58:43 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/19 17:21:06 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -139,6 +139,7 @@ t_text_list		*tokenizer_scmd_text(char *scmd_text);
 bool			is_valid_redirect_syntax(t_text_list *cur);
 bool			extract_redirect(t_text_list **token_p, t_redirect **redir_p);
 char			**token2ecmds(t_text_list *tokens);
+char			*token2path(char *token);
 
 /* env function */
 bool			is_valid_identifier(char *string);

--- a/src/data/add_struct_redirect.c
+++ b/src/data/add_struct_redirect.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/22 22:35:12 by miyuu             #+#    #+#             */
-/*   Updated: 2025/03/14 23:27:14 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/19 17:24:26 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,7 +29,9 @@ t_redirect	*add_struct_redirect(int type, int from_fd, char *path)
 		return (NULL);
 	new->type = type;
 	new->from_fd = from_fd;
-	new->path = ft_strdup(path);
+	new->path = token2path(path);
+	if (!new->path)
+		return (NULL);
 	new->next = NULL;
 	return (new);
 }

--- a/src/data/pipe2scmd_list.c
+++ b/src/data/pipe2scmd_list.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:23:38 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/17 19:45:23 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/20 08:47:37 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ t_simple_cmd	*pipe2scmd_list(const char *cmd_line)
 		if (!tokens)
 			return (NULL);
 		*new_scmd_addr = load_simple_cmd(tokens);
-		if (!new_scmd_addr)
+		if (!*new_scmd_addr)
 			return (NULL);
 		new_scmd_addr = &((*new_scmd_addr)->next);
 		i++;

--- a/src/data/token2path.c
+++ b/src/data/token2path.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 17:14:37 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/20 08:56:38 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/20 09:00:47 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ char	*token2path(char *token)
 
 	expanded = expand_single_token(token);
 	if (expanded == NULL)
-		perror_exit();
+		perror_exit(NULL);
 	if (null_terminated_array_len((void **)expanded) != 1)
 	{
 		ft_fprintf(ft_stderr(), "bash: %s: ambiguous redirect\n", token);

--- a/src/data/token2path.c
+++ b/src/data/token2path.c
@@ -1,0 +1,33 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   token2path.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/03/19 17:14:37 by tkondo            #+#    #+#             */
+/*   Updated: 2025/03/19 17:20:19 by tkondo           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function: token2path
+ * ----------------------------
+ * expand token to file path
+ */
+char	*token2path(char *token)
+{
+	char	**expanded;
+
+	expanded = expand_single_token(token);
+	if (expanded == NULL)
+		perror_exit("bash: ");
+	if (null_terminated_array_len((void **)expanded) != 1)
+	{
+		ft_fprintf(ft_stderr(), "bash: %s: ambiguous redirect\n", token);
+		return (NULL);
+	}
+	return (expanded[0]);
+}

--- a/src/data/token2path.c
+++ b/src/data/token2path.c
@@ -6,7 +6,7 @@
 /*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/19 17:14:37 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/19 17:20:19 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/03/20 08:56:38 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ char	*token2path(char *token)
 
 	expanded = expand_single_token(token);
 	if (expanded == NULL)
-		perror_exit("bash: ");
+		perror_exit();
 	if (null_terminated_array_len((void **)expanded) != 1)
 	{
 		ft_fprintf(ft_stderr(), "bash: %s: ambiguous redirect\n", token);


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
リダイレクトのpathを展開する処理を追加

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
リダイレクトのpathを展開するようにした
## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
なし
## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```sh
make -C debug test ./test-cases/expand-redirect.txt
```

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

- 関連Issue: #28
  perror_returnに渡す引数が空文字列の場合にNULL同様`: `が追記されないため、エラー文に差分がある
  本PRでは射程外とし当該Issueの対応で修正する
