### PR TITLE
fix: クォートのみで実行した場合のバグを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/04/03 20:05:08 by miyuu            ###   ########.fr        #
+#    Updated: 2025/04/05 16:07:06 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -40,6 +40,7 @@ TARGET =\
 	command/get_path\
 	command/exec_error_handling\
 	command/command_not_found_handle\
+	command/exec_with_path\
 	data/free_redirects\
 	data/free_simple_cmds\
 	data/free_text_list\

--- a/debug/test-cases/command.txt
+++ b/debug/test-cases/command.txt
@@ -18,6 +18,20 @@ echo $?
 $HOME
 echo $?
 
+""
+echo $?
+''
+echo $?
+'""'
+echo $?
+'"''"'
+echo $?
+"     "
+echo $?
+'     '
+echo $?
+
+
 - 自作コマンドを作成
 mkdir /tmp/minishell_cmd
 echo $?
@@ -193,7 +207,7 @@ date
 echo $?
 /bin/ls | /usr/bin/wc
 echo $?
-/bin/cat | /bin/ls
+/bin/ls | /bin/cat
 echo $?
 
 chmod 777 /tmp/minishell_cmd

--- a/debug/test-cases/pipe.txt
+++ b/debug/test-cases/pipe.txt
@@ -1,4 +1,9 @@
 ls . | wc -l
 echo $?
+"" | ''  | "   "
+echo $?
 cat | cat | ls
+
+
+
 echo $?

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/03 20:05:35 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/05 16:06:29 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -121,6 +121,7 @@ int				builtin_unset(char **argv);
 int				command_not_found_handle(char *cmd);
 int				exec_error_handling(char *path, int status, int err_num);
 const char		*get_path(const char *ecmds);
+int				exec_with_path(const char *path, char *const argv[]);
 
 /* data function */
 t_redirect		*add_struct_redirect(int type, int from_fd, char *path);

--- a/libft/src/ft_exec.c
+++ b/libft/src/ft_exec.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 15:19:38 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/21 16:49:59 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/04/02 03:07:59 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,6 +80,8 @@ int	ft_execvp(const char *path, char *const argv[])
 	const char	*abs_path;
 	int			ret;
 
+	if (path[0] == '\0')
+		return (127);
 	if (ft_strchr(path, '/') != NULL)
 		return (execve(path, argv, NULL));
 	abs_path = find_path(path);

--- a/libft/src/ft_exec.c
+++ b/libft/src/ft_exec.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/01/04 15:19:38 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/02 03:07:59 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/03/21 16:49:59 by tkondo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,8 +80,6 @@ int	ft_execvp(const char *path, char *const argv[])
 	const char	*abs_path;
 	int			ret;
 
-	if (path[0] == '\0')
-		return (127);
 	if (ft_strchr(path, '/') != NULL)
 		return (execve(path, argv, NULL));
 	abs_path = find_path(path);

--- a/src/command/exec_with_path.c
+++ b/src/command/exec_with_path.c
@@ -1,0 +1,93 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exec_with_path.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/05 16:02:45 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/05 16:07:30 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <_ft_unistd.h>
+#include <ft_stdlib.h>
+
+static char	*create_path(char *dir, const char *name)
+{
+	char	*tmp;
+	char	*path;
+
+	tmp = ft_strjoin(dir, "/");
+	path = ft_strjoin(tmp, name);
+	free(tmp);
+	return (path);
+}
+
+static char	*get_cwd_exec_path(const char *name)
+{
+	char	*cur_dir;
+	char	*path;
+
+	cur_dir = getcwd(NULL, 0);
+	if (!cur_dir)
+		return (NULL);
+	path = create_path(cur_dir, name);
+	free(cur_dir);
+	return (path);
+}
+
+static void	free_dirs(char **dirs)
+{
+	size_t	i;
+
+	i = 0;
+	while (dirs && dirs[i])
+	{
+		free(dirs[i]);
+		i++;
+	}
+	free(dirs);
+}
+
+static const char	*find_path(const char *name)
+{
+	char	*path;
+	char	**dirs;
+	size_t	i;
+
+	if (ft_getenv("PATH") == NULL)
+		return ((const char *)get_cwd_exec_path(name));
+	dirs = ft_split(ft_getenv("PATH"), ':');
+	i = 0;
+	while (dirs && dirs[i])
+	{
+		path = create_path(dirs[i], name);
+		if (access(path, F_OK) == 0)
+		{
+			free_dirs(dirs);
+			return ((const char *)path);
+		}
+		free(path);
+		i++;
+	}
+	free_dirs(dirs);
+	return (NULL);
+}
+
+int	exec_with_path(const char *path, char *const argv[])
+{
+	const char	*abs_path;
+	int			ret;
+
+	if (path[0] == '\0')
+		return (127);
+	if (ft_strchr(path, '/') != NULL)
+		return (execve(path, argv, NULL));
+	abs_path = find_path(path);
+	if (abs_path == NULL)
+		return (127);
+	ret = execve(abs_path, argv, NULL);
+	free((void *)abs_path);
+	return (ret);
+}

--- a/src/main/execute_simple_cmd.c
+++ b/src/main/execute_simple_cmd.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 19:30:10 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/29 20:25:54 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/05 16:05:19 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,7 @@ bool	execute_simple_cmd(const t_simple_cmd *scmd_list, int stdio_fd[2],
 		perror_with_shellname(NULL);
 		return (false);
 	}
-	status = ft_execvp(path, scmd_list->ecmds);
+	status = exec_with_path(path, scmd_list->ecmds);
 	ft_exit(exec_error_handling((char *)path, status, errno));
 	(void)envp;
 	return (false);


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
`""`や、`''`といったクォートのみでコマンド実行した際の実行結果が、`Permission denied`になるバグを修正

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- ft_exec関数を修正
  - 引数であるpathが`\0`だった場合の処理を追加。
- command.txtとpipe.txtに、テストケースを追加
## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
なし
## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```bash
make -B -C debug test test-cases/command.txt
```

```bash
make -B -C debug test test-cases/pipe.txt
```

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

- 関連Issue: #76 

