### PR TITLE
feat: exitの引数が不正だった場合のエラー処理を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/03/27 20:15:56 by miyuu            ###   ########.fr        #
+#    Updated: 2025/04/03 20:05:08 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -133,6 +133,7 @@ TARGET =\
 	utils/get_error_type\
 	utils/get_error_type_p\
 	utils/perror_with_shellname\
+	utils/is_numeric\
 	signal/set_handlers_for_prompt\
 	signal/set_handlers_default\
 	signal/set_handlers_for_process\

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/29 20:25:54 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/03 20:05:35 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -240,5 +240,6 @@ t_error_type	*get_error_type_p(void);
 void			set_error_type(t_error_type err_type);
 t_error_type	get_error_type(void);
 t_error_type	*get_error_type_p(void);
+bool			is_numeric(const char *str);
 
 #endif

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_exit.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: tkondo <tkondo@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/21 18:33:01 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/03 18:09:02 by tkondo           ###   ########.fr       */
+/*   Updated: 2025/04/03 02:59:30 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,15 +20,41 @@
  *
  *  TODO: handle errors
  */
+bool	is_numeric(char *str)
+{
+	size_t	i;
+
+	i = 0;
+	if (str[0] == '+' || str[0] == '-')
+		i++;
+	while (str[i])
+	{
+		if (ft_isdigit(str[i]) == 0)
+			return (false);
+		i++;
+	}
+	return (true);
+}
+
 int	builtin_exit(char **argv)
 {
 	int	status;
 
+	ft_fprintf(ft_stderr(), "exit\n");
+	if (argv[0] != NULL && argv[1] != NULL)
+	{
+		ft_fprintf(ft_stderr(), "bash: exit: too many arguments\n");
+		return (1);
+	}
 	if (argv == NULL || argv[0] == NULL)
 		status = (int)get_exit_status();
+	else if (argv[0][0]== '\0' || !is_numeric(argv[0]))
+	{
+		status = 2;
+		ft_fprintf(ft_stderr(), "bash: exit: %s: numeric argument required\n", argv[0]);
+	}
 	else
 		status = ft_atoi(argv[0]);
-	ft_fprintf(ft_stderr(), "exit\n");
 	ft_exit(status);
 	return (1);
 }

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/21 18:33:01 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/03 02:59:30 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/03 20:10:54 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,40 +18,24 @@
  *  reproduce exit function on bash.
  *  exit by argv[0] if it is provided, otherwise return last command status
  *
- *  TODO: handle errors
  */
-bool	is_numeric(char *str)
-{
-	size_t	i;
-
-	i = 0;
-	if (str[0] == '+' || str[0] == '-')
-		i++;
-	while (str[i])
-	{
-		if (ft_isdigit(str[i]) == 0)
-			return (false);
-		i++;
-	}
-	return (true);
-}
-
 int	builtin_exit(char **argv)
 {
 	int	status;
 
 	ft_fprintf(ft_stderr(), "exit\n");
-	if (argv[0] != NULL && argv[1] != NULL)
+	if (is_numeric(argv[0]) == true && !(argv[1] == NULL))
 	{
 		ft_fprintf(ft_stderr(), "bash: exit: too many arguments\n");
 		return (1);
 	}
 	if (argv == NULL || argv[0] == NULL)
 		status = (int)get_exit_status();
-	else if (argv[0][0]== '\0' || !is_numeric(argv[0]))
+	else if (is_numeric(argv[0]) == false)
 	{
+		ft_fprintf(ft_stderr(), \
+			"bash: exit: %s: numeric argument required\n", argv[0]);
 		status = 2;
-		ft_fprintf(ft_stderr(), "bash: exit: %s: numeric argument required\n", argv[0]);
 	}
 	else
 		status = ft_atoi(argv[0]);

--- a/src/builtin/builtin_exit.c
+++ b/src/builtin/builtin_exit.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/21 18:33:01 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/03 20:10:54 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/05 15:51:15 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,14 +24,14 @@ int	builtin_exit(char **argv)
 	int	status;
 
 	ft_fprintf(ft_stderr(), "exit\n");
-	if (is_numeric(argv[0]) == true && !(argv[1] == NULL))
+	if (is_numeric(argv[0]) && !(argv[1] == NULL))
 	{
 		ft_fprintf(ft_stderr(), "bash: exit: too many arguments\n");
 		return (1);
 	}
 	if (argv == NULL || argv[0] == NULL)
 		status = (int)get_exit_status();
-	else if (is_numeric(argv[0]) == false)
+	else if (!is_numeric(argv[0]))
 	{
 		ft_fprintf(ft_stderr(), \
 			"bash: exit: %s: numeric argument required\n", argv[0]);

--- a/src/utils/is_numeric.c
+++ b/src/utils/is_numeric.c
@@ -1,0 +1,37 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   is_numeric.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/03 20:02:47 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/03 20:04:40 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:is_numeric
+ * ----------------------------
+ * Returns true if str is a is_numeric,
+ * false if it is a non-number (including \0).
+ */
+bool	is_numeric(const char *str)
+{
+	size_t	i;
+
+	if (str == NULL || str[0] == '\0')
+		return (false);
+	i = 0;
+	if (str[0] == '+' || str[0] == '-')
+		i++;
+	while (str[i])
+	{
+		if (ft_isdigit(str[i]) == 0)
+			return (false);
+		i++;
+	}
+	return (true);
+}


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
ビルドインであるexitに、エラー処理を追加。

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- `builtin_exit`関数に、エラー処理を追加


- 未対応の処理
   - LONG_MAX以上/LONG_MIN以下の引数がきた場合、文字列として認識される。しかし、そこまで対応する必要がないと考えたため、未定義としています。

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
なし

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

テストがうまく起動しないため、手打ちでテストした
- エラーなし
```bash
exit 
```
```bash
exit 3
```

- too many argumentsエラー 終了ステータスは1で、exitしない
```bash
exit 4 42
```
```bash
exit 42 ""
```
```bash
exit 42 hello
```

- numeric argument requiredエラー 終了ステータスは2で、exitする
```bash
exit ""
```
```bash
exit hello
```
```bash
exit hello 42
```
```bash
exit tokyo ""
```
```bash
exit hello world
```

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

- 関連Issue: #75 

