### PR TITLE
fix: 空白/空行でのexitステータスのセットバグを修正

### DIFF
--- a/debug/test-cases/command.txt
+++ b/debug/test-cases/command.txt
@@ -214,3 +214,17 @@ chmod 777 /tmp/minishell_cmd
 echo $?
 rm -r /tmp/minishell_cmd
 echo $?
+
+ls -0
+
+echo $?
+
+/tmp/minishell_cmd
+
+
+echo $?
+
+<no_exist
+
+
+echo $?

--- a/src/data/get_exit_status_from_err_type.c
+++ b/src/data/get_exit_status_from_err_type.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/27 19:38:53 by miyuu             #+#    #+#             */
-/*   Updated: 2025/03/29 20:25:54 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/07 03:25:26 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 unsigned char	get_exit_status_from_err_type(t_error_type	err_type)
 {
 	if (err_type == NOERR)
-		return (0);
+		return (get_exit_status());
 	else if (err_type == ERR_SYSCALL)
 		return (1);
 	else if (err_type == ERR_AMBRDIR)


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
 空白/空行後のexitステータスが、毎回0になってしまうバグを修正した

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->
- get_exit_status_from_err_type関数内で、err_typeがNOERRだった場合、現時点でセットされている終了ステータスをreturnするように変更
- command.txtに、空行での終了ステータスを確認するテストケースを作成

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->

## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```bash
make -B -C debug test
```

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->

- 関連Issue: #77 

