### PR TITLE
reat: ヒアドクをランダムなファイル名になるようにした

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/04/10 16:19:09 by miyuu            ###   ########.fr        #
+#    Updated: 2025/04/12 18:53:38 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -61,7 +61,7 @@ TARGET =\
 	data/parse_general_token\
 	data/parse_number_redir_token\
 	data/outerlen_between_quote\
-	data/create_tmp_file\
+	data/create_heredoc_file\
 	data/handle_heredoc\
 	data/add_redir_list_last\
 	data/token2ecmds\

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/09 00:35:59 by tkondo            #+#    #+#              #
-#    Updated: 2025/04/12 18:53:38 by miyuu            ###   ########.fr        #
+#    Updated: 2025/04/12 20:42:13 by miyuu            ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -77,6 +77,9 @@ TARGET =\
 	data/is_valid_quote_syntax\
 	data/get_exit_status_from_err_type\
 	data/expand_all_tokens\
+	data/convert_bytes2hex\
+	data/create_heredoc_randfile\
+	data/create_heredoc_seqfile\
 	env/is_valid_identifier\
 	env/load_variable_assignment\
 	env/register_env\

--- a/debug/main/test_heredoc_filename.c
+++ b/debug/main/test_heredoc_filename.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   create_tmp_file.c                                  :+:      :+:    :+:   */
+/*   test_heredoc_filename.c                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/03/04 14:43:09 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/12 17:34:50 by miyuu            ###   ########.fr       */
+/*   Created: 2025/02/26 12:39:47 by tkondo            #+#    #+#             */
+/*   Updated: 2025/04/12 17:33:16 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ char	*bytes_to_hex(unsigned char *bytes, int len)
 	return (hex_out);
 }
 
-char	*create_random_filename(int fd_random)
+char	*new_create_random_filename(int fd_random)
 {
 	int				new_fd;
 	char			*filename;
@@ -47,16 +47,18 @@ char	*create_random_filename(int fd_random)
 										!= sizeof(rand_bytes))
 			close(fd_random);
 		hex_str = bytes_to_hex(rand_bytes, 4);
+		printf("bytes_to_hex : %s\n", hex_str);
 		filename = ft_strjoin("/tmp/heredoc_", hex_str);
 		if (!filename)
 			close(fd_random);
+
 		new_fd = open(filename, O_CREAT | O_EXCL, 0600);
 	}
 	close(new_fd);
 	return (filename);
 }
 
-char	*create_tmp_file(void)
+char	*new_create_tmp_file(void)
 {
 	int				fd_random;
 	char			*filename;
@@ -68,37 +70,19 @@ char	*create_tmp_file(void)
 		print_errmsg_with_str(EM_SYSCALL, NULL);
 		return (NULL);
 	}
-	filename = create_random_filename(fd_random);
+	filename = new_create_random_filename(fd_random);
 	close(fd_random);
 	return (filename);
 }
 
-/*
- * Function:create_tmp_file
- * ----------------------------
- * Creates a unique /tmp/heredoc_* file and returns its path.
- */
-// char	*create_tmp_file(void)
-// {
-// 	int		count;
-// 	char	*filename;
-// 	int		fd;
+// **📝 テスト実行**
+int	main(void)
+{
+	char	*filename;
 
-// 	count = 0;
-// 	filename = NULL;
-// 	fd = -1;
-// 	while (fd == -1)
-// 	{
-// 		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
-// 					ft_g_mmadd(ft_itoa(count++))));
-// 		if (!filename)
-// 		{
-// 			set_error_type(ERR_SYSCALL);
-// 			print_errmsg_with_str(EM_SYSCALL, NULL);
-// 			return (NULL);
-// 		}
-// 		fd = open(filename, O_CREAT | O_EXCL, 0600);
-// 	}
-// 	close(fd);
-// 	return (filename);
-// }
+	filename = new_create_tmp_file();
+	printf("%s\n", filename);
+	free(filename);
+
+	return (0);
+}

--- a/debug/main/test_heredoc_filename.c
+++ b/debug/main/test_heredoc_filename.c
@@ -6,22 +6,27 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 12:39:47 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/12 17:33:16 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 19:54:21 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-char	*bytes_to_hex(unsigned char *bytes, int len)
+
+char	*bytes_to_hex(unsigned char *bytes, size_t len)
 {
 	const char	*hex_base;
 	char		*hex_out;
 	size_t		i;
 
 	hex_base = "0123456789abcdef";
-	hex_out = ft_g_mmadd(malloc(len * 2 + 1));
+	hex_out = ft_g_mmmalloc(len * 2 + 1);
 	if (!hex_out)
+	{
+		set_error_type(ERR_SYSCALL);
+		print_errmsg_with_str(EM_SYSCALL, NULL);
 		return (NULL);
+	}
 	i = 0;
 	while (i < len)
 	{
@@ -33,7 +38,7 @@ char	*bytes_to_hex(unsigned char *bytes, int len)
 	return (hex_out);
 }
 
-char	*new_create_random_filename(int fd_random)
+char	*create_random_filename(int fd_random)
 {
 	int				new_fd;
 	char			*filename;
@@ -47,30 +52,56 @@ char	*new_create_random_filename(int fd_random)
 										!= sizeof(rand_bytes))
 			close(fd_random);
 		hex_str = bytes_to_hex(rand_bytes, 4);
-		printf("bytes_to_hex : %s\n", hex_str);
-		filename = ft_strjoin("/tmp/heredoc_", hex_str);
+		if (hex_str == NULL)
+			return (NULL);
+		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_", hex_str));
 		if (!filename)
-			close(fd_random);
-
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
 		new_fd = open(filename, O_CREAT | O_EXCL, 0600);
 	}
 	close(new_fd);
 	return (filename);
 }
 
-char	*new_create_tmp_file(void)
+char	*create_nbr_filename(void)
+{
+	int		count;
+	char	*filename;
+	int		fd;
+
+	count = 0;
+	filename = NULL;
+	fd = -1;
+	while (fd == -1)
+	{
+		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
+					ft_g_mmadd(ft_itoa(count++))));
+		if (!filename)
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
+		fd = open(filename, O_CREAT | O_EXCL, 0600);
+	}
+	close(fd);
+	return (filename);
+}
+
+char	*new_create_heredoc_file(void)
 {
 	int				fd_random;
 	char			*filename;
 
 	fd_random = open("/dev/urandom", O_RDONLY);
 	if (fd_random == -1)
-	{
-		set_error_type(ERR_SYSCALL);
-		print_errmsg_with_str(EM_SYSCALL, NULL);
-		return (NULL);
-	}
-	filename = new_create_random_filename(fd_random);
+		filename = create_nbr_filename();
+	else
+		filename = create_random_filename(fd_random);
 	close(fd_random);
 	return (filename);
 }
@@ -80,7 +111,7 @@ int	main(void)
 {
 	char	*filename;
 
-	filename = new_create_tmp_file();
+	filename = new_create_heredoc_file();
 	printf("%s\n", filename);
 	free(filename);
 

--- a/debug/main/test_heredoc_filename.c
+++ b/debug/main/test_heredoc_filename.c
@@ -6,18 +6,17 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 12:39:47 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/12 19:54:21 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 20:42:44 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-
-char	*bytes_to_hex(unsigned char *bytes, size_t len)
+char	*convert_bytes2hex(unsigned char *bytes, size_t len)
 {
-	const char	*hex_base;
-	char		*hex_out;
-	size_t		i;
+	char	*hex_base;
+	char	*hex_out;
+	size_t	i;
 
 	hex_base = "0123456789abcdef";
 	hex_out = ft_g_mmmalloc(len * 2 + 1);
@@ -38,7 +37,7 @@ char	*bytes_to_hex(unsigned char *bytes, size_t len)
 	return (hex_out);
 }
 
-char	*create_random_filename(int fd_random)
+char	*create_heredoc_randfile(int fd_random)
 {
 	int				new_fd;
 	char			*filename;
@@ -51,10 +50,10 @@ char	*create_random_filename(int fd_random)
 		if (read(fd_random, rand_bytes, sizeof(rand_bytes)) \
 										!= sizeof(rand_bytes))
 			close(fd_random);
-		hex_str = bytes_to_hex(rand_bytes, 4);
+		hex_str = convert_bytes2hex(rand_bytes, 4);
 		if (hex_str == NULL)
 			return (NULL);
-		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_", hex_str));
+		filename = ft_g_mmadd(ft_strjoin(HEREDOC_TMP_PREFIX, hex_str));
 		if (!filename)
 		{
 			set_error_type(ERR_SYSCALL);
@@ -67,7 +66,7 @@ char	*create_random_filename(int fd_random)
 	return (filename);
 }
 
-char	*create_nbr_filename(void)
+char	*create_heredoc_seqfile(void)
 {
 	int		count;
 	char	*filename;
@@ -78,7 +77,7 @@ char	*create_nbr_filename(void)
 	fd = -1;
 	while (fd == -1)
 	{
-		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
+		filename = ft_g_mmadd(ft_strjoin(HEREDOC_TMP_PREFIX,
 					ft_g_mmadd(ft_itoa(count++))));
 		if (!filename)
 		{
@@ -98,11 +97,13 @@ char	*new_create_heredoc_file(void)
 	char			*filename;
 
 	fd_random = open("/dev/urandom", O_RDONLY);
-	if (fd_random == -1)
-		filename = create_nbr_filename();
+	if (fd_random > 0)
+	{
+		filename = create_heredoc_randfile(fd_random);
+		close(fd_random);
+	}
 	else
-		filename = create_random_filename(fd_random);
-	close(fd_random);
+		filename = create_heredoc_seqfile();
 	return (filename);
 }
 

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/12 18:53:46 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 20:42:30 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,6 +39,7 @@
 /* macro */
 # define PROMPT "minishell$ "
 # define SHELL_NAME "bash: "
+# define HEREDOC_TMP_PREFIX "/tmp/heredoc_"
 
 /* struct */
 typedef struct s_execute_session	t_execute_session;
@@ -177,6 +178,9 @@ char			*validate_cmd_line_syntax(const char *cmd_line);
 bool			is_valid_quote_syntax(const char *cmd_line, char target_quote);
 unsigned char	get_exit_status_from_err_type(t_error_type	err_type);
 char			**expand_all_tokens(t_text_list *tokens);
+char			*convert_bytes2hex(unsigned char *bytes, size_t len);
+char			*create_heredoc_randfile(int fd_random);
+char			*create_heredoc_seqfile(void);
 
 /* env function */
 bool			is_valid_identifier(char *string);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/16 20:15:15 by tkondo            #+#    #+#             */
-/*   Updated: 2025/04/10 16:59:56 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 18:53:46 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -140,7 +140,7 @@ int				exec_with_path(const char *path, char *const argv[]);
 /* data function */
 t_redirect		*add_struct_redirect(int type, int from_fd, char *path);
 void			add_struct_text_list(t_text_list **head, t_text_list *new);
-char			*create_tmp_file(void);
+char			*create_heredoc_file(void);
 void			free_text_list(t_text_list *scmds);
 void			free_redirects(t_redirect *redir);
 void			free_simple_cmds(t_simple_cmd *scmd_list);

--- a/src/data/convert_bytes2hex.c
+++ b/src/data/convert_bytes2hex.c
@@ -1,0 +1,46 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   convert_bytes2hex.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/12 20:29:11 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/12 20:41:30 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:convert_bytes2hex
+ * ----------------------------
+ * Converts an array of bytes into a hexadecimal string.
+ *
+ * bytes: pointer to the byte array
+ * len: length of the byte array
+ */
+char	*convert_bytes2hex(unsigned char *bytes, size_t len)
+{
+	char	*hex_base;
+	char	*hex_out;
+	size_t	i;
+
+	hex_base = "0123456789abcdef";
+	hex_out = ft_g_mmmalloc(len * 2 + 1);
+	if (!hex_out)
+	{
+		set_error_type(ERR_SYSCALL);
+		print_errmsg_with_str(EM_SYSCALL, NULL);
+		return (NULL);
+	}
+	i = 0;
+	while (i < len)
+	{
+		hex_out[i * 2] = hex_base[(bytes[i] >> 4) & 0xF];
+		hex_out[i * 2 + 1] = hex_base[bytes[i] & 0xF];
+		i++;
+	}
+	hex_out[len * 2] = '\0';
+	return (hex_out);
+}

--- a/src/data/create_heredoc_file.c
+++ b/src/data/create_heredoc_file.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   create_tmp_file.c                                  :+:      :+:    :+:   */
+/*   create_heredoc_file.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mfunakos <mfunakos@student.42.fr>          +#+  +:+       +#+        */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
-/*   Created: 2025/03/04 14:43:09 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/12 18:07:33 by mfunakos         ###   ########.fr       */
+/*   Created: 2025/04/12 18:54:36 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/12 19:55:27 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,9 +19,13 @@ char	*bytes_to_hex(unsigned char *bytes, size_t len)
 	size_t		i;
 
 	hex_base = "0123456789abcdef";
-	hex_out = ft_g_mmadd(malloc(len * 2 + 1));
+	hex_out = ft_g_mmmalloc(len * 2 + 1);
 	if (!hex_out)
+	{
+		set_error_type(ERR_SYSCALL);
+		print_errmsg_with_str(EM_SYSCALL, NULL);
 		return (NULL);
+	}
 	i = 0;
 	while (i < len)
 	{
@@ -47,38 +51,68 @@ char	*create_random_filename(int fd_random)
 										!= sizeof(rand_bytes))
 			close(fd_random);
 		hex_str = bytes_to_hex(rand_bytes, 4);
+		if (hex_str == NULL)
+			return (NULL);
 		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_", hex_str));
 		if (!filename)
-			close(fd_random);
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
 		new_fd = open(filename, O_CREAT | O_EXCL, 0600);
 	}
 	close(new_fd);
 	return (filename);
 }
 
-char	*create_tmp_file(void)
+char	*create_nbr_filename(void)
+{
+	int		count;
+	char	*filename;
+	int		fd;
+
+	count = 0;
+	filename = NULL;
+	fd = -1;
+	while (fd == -1)
+	{
+		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
+					ft_g_mmadd(ft_itoa(count++))));
+		if (!filename)
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
+		fd = open(filename, O_CREAT | O_EXCL, 0600);
+	}
+	close(fd);
+	return (filename);
+}
+
+char	*create_heredoc_file(void)
 {
 	int				fd_random;
 	char			*filename;
 
 	fd_random = open("/dev/urandom", O_RDONLY);
-	if (fd_random == -1)
+	if (fd_random > 0)
 	{
-		set_error_type(ERR_SYSCALL);
-		print_errmsg_with_str(EM_SYSCALL, NULL);
-		return (NULL);
+		filename = create_random_filename(fd_random);
+		close(fd_random);
 	}
-	filename = create_random_filename(fd_random);
-	close(fd_random);
+	else
+		filename = create_nbr_filename();
 	return (filename);
 }
 
 /*
- * Function:create_tmp_file
+ * Function:create_heredoc_file
  * ----------------------------
  * Creates a unique /tmp/heredoc_* file and returns its path.
  */
-// char	*create_tmp_file(void)
+// char	*create_heredoc_file(void)
 // {
 // 	int		count;
 // 	char	*filename;

--- a/src/data/create_heredoc_file.c
+++ b/src/data/create_heredoc_file.c
@@ -6,91 +6,17 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/12 18:54:36 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/12 19:55:27 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 20:39:53 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-char	*bytes_to_hex(unsigned char *bytes, size_t len)
-{
-	const char	*hex_base;
-	char		*hex_out;
-	size_t		i;
-
-	hex_base = "0123456789abcdef";
-	hex_out = ft_g_mmmalloc(len * 2 + 1);
-	if (!hex_out)
-	{
-		set_error_type(ERR_SYSCALL);
-		print_errmsg_with_str(EM_SYSCALL, NULL);
-		return (NULL);
-	}
-	i = 0;
-	while (i < len)
-	{
-		hex_out[i * 2] = hex_base[(bytes[i] >> 4) & 0xF];
-		hex_out[i * 2 + 1] = hex_base[bytes[i] & 0xF];
-		i++;
-	}
-	hex_out[len * 2] = '\0';
-	return (hex_out);
-}
-
-char	*create_random_filename(int fd_random)
-{
-	int				new_fd;
-	char			*filename;
-	unsigned char	rand_bytes[4];
-	char			*hex_str;
-
-	new_fd = -1;
-	while (new_fd == -1)
-	{
-		if (read(fd_random, rand_bytes, sizeof(rand_bytes)) \
-										!= sizeof(rand_bytes))
-			close(fd_random);
-		hex_str = bytes_to_hex(rand_bytes, 4);
-		if (hex_str == NULL)
-			return (NULL);
-		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_", hex_str));
-		if (!filename)
-		{
-			set_error_type(ERR_SYSCALL);
-			print_errmsg_with_str(EM_SYSCALL, NULL);
-			return (NULL);
-		}
-		new_fd = open(filename, O_CREAT | O_EXCL, 0600);
-	}
-	close(new_fd);
-	return (filename);
-}
-
-char	*create_nbr_filename(void)
-{
-	int		count;
-	char	*filename;
-	int		fd;
-
-	count = 0;
-	filename = NULL;
-	fd = -1;
-	while (fd == -1)
-	{
-		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
-					ft_g_mmadd(ft_itoa(count++))));
-		if (!filename)
-		{
-			set_error_type(ERR_SYSCALL);
-			print_errmsg_with_str(EM_SYSCALL, NULL);
-			return (NULL);
-		}
-		fd = open(filename, O_CREAT | O_EXCL, 0600);
-	}
-	close(fd);
-	return (filename);
-}
-
+/*
+ * Function:create_heredoc_file
+ * ----------------------------
+ * Creates a unique /tmp/heredoc_* file and returns its path.
+ */
 char	*create_heredoc_file(void)
 {
 	int				fd_random;
@@ -99,40 +25,10 @@ char	*create_heredoc_file(void)
 	fd_random = open("/dev/urandom", O_RDONLY);
 	if (fd_random > 0)
 	{
-		filename = create_random_filename(fd_random);
+		filename = create_heredoc_randfile(fd_random);
 		close(fd_random);
 	}
 	else
-		filename = create_nbr_filename();
+		filename = create_heredoc_seqfile();
 	return (filename);
 }
-
-/*
- * Function:create_heredoc_file
- * ----------------------------
- * Creates a unique /tmp/heredoc_* file and returns its path.
- */
-// char	*create_heredoc_file(void)
-// {
-// 	int		count;
-// 	char	*filename;
-// 	int		fd;
-
-// 	count = 0;
-// 	filename = NULL;
-// 	fd = -1;
-// 	while (fd == -1)
-// 	{
-// 		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_",
-// 					ft_g_mmadd(ft_itoa(count++))));
-// 		if (!filename)
-// 		{
-// 			set_error_type(ERR_SYSCALL);
-// 			print_errmsg_with_str(EM_SYSCALL, NULL);
-// 			return (NULL);
-// 		}
-// 		fd = open(filename, O_CREAT | O_EXCL, 0600);
-// 	}
-// 	close(fd);
-// 	return (filename);
-// }

--- a/src/data/create_heredoc_randfile.c
+++ b/src/data/create_heredoc_randfile.c
@@ -1,0 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   create_heredoc_randfile.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/12 20:31:58 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/12 20:39:20 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:create_heredoc_randfile
+ * ----------------------------
+ * Create a unique /tmp/heredoc_<hex> filename using random bytes
+ *
+ * fd_random: file descriptor for /dev/urandom
+ */
+char	*create_heredoc_randfile(int fd_random)
+{
+	int				new_fd;
+	char			*filename;
+	unsigned char	rand_bytes[4];
+	char			*hex_str;
+
+	new_fd = -1;
+	while (new_fd == -1)
+	{
+		if (read(fd_random, rand_bytes, sizeof(rand_bytes)) \
+										!= sizeof(rand_bytes))
+			close(fd_random);
+		hex_str = convert_bytes2hex(rand_bytes, 4);
+		if (hex_str == NULL)
+			return (NULL);
+		filename = ft_g_mmadd(ft_strjoin(HEREDOC_TMP_PREFIX, hex_str));
+		if (!filename)
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
+		new_fd = open(filename, O_CREAT | O_EXCL, 0600);
+	}
+	close(new_fd);
+	return (filename);
+}

--- a/src/data/create_heredoc_seqfile.c
+++ b/src/data/create_heredoc_seqfile.c
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   create_heredoc_seqfile.c                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/04/12 20:34:05 by miyuu             #+#    #+#             */
+/*   Updated: 2025/04/12 20:39:14 by miyuu            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include <minishell.h>
+
+/*
+ * Function:create_heredoc_seqfile
+ * ----------------------------
+ * Creates a unique /tmp/heredoc_<number> filename
+ * by incrementing a counter until a non-existing filename is found.
+ */
+char	*create_heredoc_seqfile(void)
+{
+	int		count;
+	char	*filename;
+	int		fd;
+
+	count = 0;
+	filename = NULL;
+	fd = -1;
+	while (fd == -1)
+	{
+		filename = ft_g_mmadd(ft_strjoin(HEREDOC_TMP_PREFIX,
+					ft_g_mmadd(ft_itoa(count++))));
+		if (!filename)
+		{
+			set_error_type(ERR_SYSCALL);
+			print_errmsg_with_str(EM_SYSCALL, NULL);
+			return (NULL);
+		}
+		fd = open(filename, O_CREAT | O_EXCL, 0600);
+	}
+	close(fd);
+	return (filename);
+}

--- a/src/data/create_tmp_file.c
+++ b/src/data/create_tmp_file.c
@@ -6,13 +6,13 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 14:43:09 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/12 17:34:50 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 18:01:33 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-char	*bytes_to_hex(unsigned char *bytes, int len)
+char	*bytes_to_hex(unsigned char *bytes, size_t len)
 {
 	const char	*hex_base;
 	char		*hex_out;

--- a/src/data/create_tmp_file.c
+++ b/src/data/create_tmp_file.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   create_tmp_file.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
+/*   By: mfunakos <mfunakos@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 14:43:09 by miyuu             #+#    #+#             */
-/*   Updated: 2025/04/12 18:01:33 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 18:07:33 by mfunakos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,7 @@ char	*create_random_filename(int fd_random)
 										!= sizeof(rand_bytes))
 			close(fd_random);
 		hex_str = bytes_to_hex(rand_bytes, 4);
-		filename = ft_strjoin("/tmp/heredoc_", hex_str);
+		filename = ft_g_mmadd(ft_strjoin("/tmp/heredoc_", hex_str));
 		if (!filename)
 			close(fd_random);
 		new_fd = open(filename, O_CREAT | O_EXCL, 0600);

--- a/src/data/handle_heredoc.c
+++ b/src/data/handle_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 14:45:35 by miyuu             #+#    #+#             */
-/*   Updated: 2025/03/24 14:50:09 by miyuu            ###   ########.fr       */
+/*   Updated: 2025/04/12 18:53:20 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ t_redirect	*handle_heredoc(char *eof, int from_fd)
 	char		*path;
 	t_redirect	*redir;
 
-	path = create_tmp_file();
+	path = create_heredoc_file();
 	if (!path)
 		return (NULL);
 	if (!write_heredoc(eof, path))

--- a/src/read/write_until_eof_on_chproc.c
+++ b/src/read/write_until_eof_on_chproc.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   write_until_eof_on_chproc.c                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mfunakos <mfunakos@student.42.fr>          +#+  +:+       +#+        */
+/*   By: miyuu <miyuu@student.42.fr>                +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 16:18:21 by tkondo            #+#    #+#             */
-/*   Updated: 2025/03/27 17:22:22 by mfunakos         ###   ########.fr       */
+/*   Updated: 2025/04/12 15:17:40 by miyuu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@ bool	write_until_eof_on_chproc(int fd, const char *hd_eof)
 		set_handlers_for_heredoc();
 		errno = 0;
 		write_until_eof(fd, hd_eof);
+		close(fd);
 		if (errno == ENOMEM)
 			ft_exit(1);
 		ft_exit(0);


### PR DESCRIPTION
## 概要 <!-- このセクションでは、このPRの目的と概要を簡潔に説明してください。 -->
- heredoc書き込み用のファイル名を、ランダム(風)な16進数になるようにした
- heredoc に書き込む処理を行う子プロセスで、fdをcloseせずに子プロセスを終了しているバグを修正した(挙動に問題はないもののの、一応修正した。)

## 変更点 <!-- このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。 -->

- 乱数を取得できる`/dev/urandom`から取得した値を16進数に変換し、ファイル名に使用した
- `/dev/urandom`のopenに失敗した場合(`/dev/urandom`が存在しなかった場合)、以前通り「heredoc_数字」になるようにした

## 実装の方針的
- ファイルはdataディレクトリに保存してます
- `/dev/urandom` のopen()に失敗する原因として、使用可能なファイルディスクリプタが枯渇しているケースも考えられますが、そのような状況は非常に稀であるため、本実装では特別な対応はしていません。
→現状、 `/dev/urandom` のopen()に失敗したらcreate_heredoc_seqfile関数に飛ぶ。fdが枯渇している場合、この関数内のwhileで常にopenに失敗するのでwhileから抜け出せなくなる。(はず)


## 特段この点が不安で見てほしいみたいな部分
- `/dev/urandom`がちゃんと存在するか、こんどーさんのデバイスでも確認してほしいです。(校舎のPCでは想定通りに動いた)

## 影響範囲 <!-- このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。 -->
なし
## テスト <!-- このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。 -->

```bash
make -B -C debug test
```

- 単体テスト用main
```bash
make -C debug run-main main/test_heredoc_filename.c
```

- 子プロセスのfd見る用
```bash
valgrind --leak-check=full --track-origins=yes --track-fds=yes  ./minishell
```

## 関連Issue <!-- このセクションでは、このPRが関連するIssueやタスクをリンクしてください。以下のように記述します。 -->
なし

